### PR TITLE
fix: replace hardcoded timestamps in feedback round-trip test

### DIFF
--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -74,17 +74,18 @@ def test_load_feedback_missing_file(tmp_path: Path) -> None:
 
 
 def test_save_and_load_feedback_round_trip(tmp_path: Path) -> None:
+    now = datetime.now(tz=timezone.utc)
     fb1 = ArticleFeedback(
         article_hash="h1",
         source_name="Source A",
         rating=1,
-        timestamp="2026-03-18T10:00:00+00:00",
+        timestamp=(now - timedelta(hours=2)).isoformat(),
     )
     fb2 = ArticleFeedback(
         article_hash="h2",
         source_name="Source B",
         rating=-1,
-        timestamp="2026-03-18T11:00:00+00:00",
+        timestamp=(now - timedelta(hours=1)).isoformat(),
     )
     original = FeedbackStore(ratings=[fb1, fb2], last_update_id=100)
     save_feedback(original, str(tmp_path))


### PR DESCRIPTION
## Root cause

`test_save_and_load_feedback_round_trip` used hardcoded timestamps `2026-03-18T10:00:00+00:00` / `2026-03-18T11:00:00+00:00`. `save_feedback()` prunes ratings older than 30 days at write time. Once the current date passed 2026-04-17 (30 days after 2026-03-18), both ratings were silently discarded on save, and the assertion `len(loaded.ratings) == 2` began failing with `0 == 2`.

This blocked the `test` job in `daily.yml` on every scheduled run, preventing the downstream `digest` job from executing. The `discover.yml` workflow was unaffected because it has no `test` gate — which explains the one ✓ discover run observed after the break.

## Fix

Replace the two hardcoded strings with `(datetime.now(tz=timezone.utc) - timedelta(hours=N)).isoformat()`, matching the pattern already used by other tests in the same file. No production code changed.

## Test

- Previously failing test now passes: `tests/test_feedback.py::test_save_and_load_feedback_round_trip`
- Full suite: 83/83 ✅
- Ruff: clean ✅
- Mypy: clean ✅

## Review notes

- Claude `/review`: no BLOCKs
- Codex `/codex-review`: SKIPPED (Plus-OAuth timeout) — two-voice DoD gap, deferred

## Verification (async)

After merge, the next scheduled `daily.yml` run (02:00 or 13:00 UTC) should complete the `test` job and produce a `digest: YYYY-MM-DD` commit in `main`. If that run fails for an unrelated reason (expired API key, broken feed), that is a separate issue — do not reopen #32.

Closes #32