### PR TITLE
refactor: consolidate Source state — move trial/graduated/demoted to cache

### DIFF
--- a/digest/config.py
+++ b/digest/config.py
@@ -6,7 +6,10 @@ import logging
 import math
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from digest.source_scorer import SourceStateStore
 from urllib.parse import urlparse
 
 import yaml
@@ -84,7 +87,6 @@ class SourceConfig:
     enabled: bool
     priority: int = 3
     trial: bool = False
-    trial_started: str | None = None
     trial_days: int = 7
     recency_hours: int = 24
 
@@ -134,6 +136,10 @@ class Config:
     @property
     def enabled_sources(self) -> list[SourceConfig]:
         return [s for s in self.sources if s.enabled]
+
+    def effective_sources(self, source_state: "SourceStateStore") -> list[SourceConfig]:
+        """Return enabled sources excluding those demoted by runtime cache (ADR-0003)."""
+        return [s for s in self.sources if s.enabled and not source_state.is_demoted(s.name)]
 
 
 def _safe_int(value: Any, field_name: str, section: str) -> int:
@@ -424,9 +430,6 @@ def _load_sources(data: dict[str, Any]) -> list[SourceConfig]:
                 f"Config field 'trial' in sources[{i}] must be a boolean "
                 f"(true or false without quotes), got {type(raw_trial).__name__} {raw_trial!r}."
             )
-        trial_started = item.get("trial_started", None)
-        if trial_started is not None:
-            trial_started = str(trial_started)
         raw_trial_days = item.get("trial_days", 7)
         if isinstance(raw_trial_days, bool) or not isinstance(raw_trial_days, int):
             raise ValueError(
@@ -446,7 +449,6 @@ def _load_sources(data: dict[str, Any]) -> list[SourceConfig]:
                 enabled=raw_enabled,
                 priority=raw_priority,
                 trial=raw_trial,
-                trial_started=trial_started,
                 trial_days=raw_trial_days,
                 recency_hours=raw_recency,
             )

--- a/digest/main.py
+++ b/digest/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import dataclasses
 import logging
 import os
 import re
@@ -545,18 +546,21 @@ async def run(
     )
     from digest.radar import collect, pick_top_articles, save_dedup_cache, summarize_all
     from digest.source_scorer import (
-        apply_trial_decisions,
+        apply_trial_decisions_to_cache,
         calculate_effective_priorities,
         evaluate_trial_sources,
+        load_source_state,
         load_stats,
+        save_source_state,
         save_stats,
     )
 
     _t_run_start = time.monotonic()
     config = load_config(config_path)
     logger = logging.getLogger(__name__)
-    feeds_count = len(config.enabled_sources)
     cache_dir = ".cache"
+    source_state = load_source_state(cache_dir)
+    feeds_count = len(config.enabled_sources)
     cleanup_stale_tmp(Path(cache_dir))
     source_stats = load_stats(cache_dir)
     feedback_store = load_feedback(cache_dir)
@@ -582,11 +586,14 @@ async def run(
             if score is not None:
                 feedback_scores[source.name] = score
         effective_priorities = calculate_effective_priorities(
-            config.enabled_sources, source_stats, feedback_scores, config.adaptive
+            config.effective_sources(source_state), source_stats, feedback_scores, config.adaptive
         )
 
-    # Radar pipeline
-    articles_by_category, cache = await collect(config, effective_priorities=effective_priorities)
+    run_config = dataclasses.replace(
+        config,
+        sources=[s for s in config.sources if s.enabled and not source_state.is_demoted(s.name)],
+    )
+    articles_by_category, cache = await collect(run_config, effective_priorities=effective_priorities)
     total_articles = sum(len(arts) for arts in articles_by_category.values())
 
     def _empty_stats(n_articles: int = 0) -> RunStats:
@@ -717,10 +724,10 @@ async def run(
         if config.adaptive.enabled:
             today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
             promote, demote, needs_start = evaluate_trial_sources(
-                config.enabled_sources, source_stats, today
+                config.enabled_sources, source_stats, today, source_state
             )
             if promote or demote or needs_start:
-                apply_trial_decisions(config_path, promote, demote, needs_start=needs_start)
+                apply_trial_decisions_to_cache(source_state, promote, demote, today, needs_start)
                 sources_promoted = len(promote)
                 sources_demoted = len(demote)
     else:
@@ -729,6 +736,7 @@ async def run(
         feedback_store.ratings = feedback_store.ratings[:saved_ratings_count]
 
     save_feedback(feedback_store, cache_dir)
+    save_source_state(source_state, cache_dir)
     save_stats(source_stats, cache_dir, active_sources={s.name for s in config.enabled_sources})
 
     return RunStats(

--- a/digest/source_scorer.py
+++ b/digest/source_scorer.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
-import shutil
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,6 +17,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 STATS_FILE = "source_stats.json"
+SOURCE_STATE_FILE = "source_state.json"
+SOURCE_STATE_SCHEMA_VERSION = 1
 HISTORY_MAX_DAYS = 30
 
 
@@ -40,6 +40,99 @@ class SourceStats:
     avg_description_length: float = 0.0
     last_seen: str | None = None
     history: list[DailySnapshot] = field(default_factory=list)
+
+
+@dataclass
+class SourceStateEntry:
+    trial_started: str | None = None
+    graduated: bool = False
+    demoted: bool = False
+
+
+@dataclass
+class SourceStateStore:
+    schema_version: int = SOURCE_STATE_SCHEMA_VERSION
+    sources: dict[str, SourceStateEntry] = field(default_factory=dict)
+
+    def _entry(self, name: str) -> SourceStateEntry:
+        if name not in self.sources:
+            self.sources[name] = SourceStateEntry()
+        return self.sources[name]
+
+    def is_demoted(self, name: str) -> bool:
+        return self.sources.get(name, SourceStateEntry()).demoted
+
+    def is_graduated(self, name: str) -> bool:
+        return self.sources.get(name, SourceStateEntry()).graduated
+
+    def get_trial_started(self, name: str) -> str | None:
+        return self.sources.get(name, SourceStateEntry()).trial_started
+
+    def set_trial_started(self, name: str, date: str) -> None:
+        self._entry(name).trial_started = date
+
+    def mark_graduated(self, name: str) -> None:
+        entry = self._entry(name)
+        entry.graduated = True
+        entry.trial_started = None
+
+    def mark_demoted(self, name: str) -> None:
+        self._entry(name).demoted = True
+
+
+def load_source_state(cache_dir: str) -> SourceStateStore:
+    """Load source runtime state from JSON cache. Return empty store if missing or corrupt."""
+    path = Path(cache_dir) / SOURCE_STATE_FILE
+    if not path.exists():
+        return SourceStateStore()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            logger.warning("Invalid source_state.json format, expected dict — starting fresh")
+            return SourceStateStore()
+        version = data.get("schema_version", 0)
+        if version != SOURCE_STATE_SCHEMA_VERSION:
+            logger.warning(
+                "source_state.json schema_version=%s unsupported (expected %s) — starting fresh",
+                version,
+                SOURCE_STATE_SCHEMA_VERSION,
+            )
+            return SourceStateStore()
+        sources: dict[str, SourceStateEntry] = {}
+        for name, raw in data.get("sources", {}).items():
+            try:
+                sources[name] = SourceStateEntry(
+                    trial_started=raw.get("trial_started"),
+                    graduated=bool(raw.get("graduated", False)),
+                    demoted=bool(raw.get("demoted", False)),
+                )
+            except (KeyError, TypeError, AttributeError) as exc:
+                logger.warning("Skipping malformed source_state entry '%s': %s", name, exc)
+        return SourceStateStore(schema_version=version, sources=sources)
+    except json.JSONDecodeError as exc:
+        logger.warning("Corrupted source_state.json — starting fresh: %s", exc)
+        return SourceStateStore()
+    except Exception as exc:
+        logger.warning("Failed to load source_state.json: %s", exc)
+        return SourceStateStore()
+
+
+def save_source_state(store: SourceStateStore, cache_dir: str) -> None:
+    """Persist source runtime state to JSON cache atomically."""
+    path = Path(cache_dir) / SOURCE_STATE_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "schema_version": store.schema_version,
+        "sources": {
+            name: asdict(entry)
+            for name, entry in store.sources.items()
+        },
+    }
+    try:
+        atomic_json_write(path, data)
+    except Exception as exc:
+        logger.warning("Failed to save source_state.json: %s", exc)
 
 
 def load_stats(cache_dir: str) -> dict[str, SourceStats]:
@@ -269,11 +362,16 @@ def evaluate_trial_sources(
     sources: list[SourceConfig],
     stats: dict[str, SourceStats],
     today: str,
+    source_state: SourceStateStore | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """Evaluate trial sources and decide which to promote or demote.
 
     Returns (promote_names, demote_names, needs_start_names).
+    trial_started is read from source_state; sources already graduated or demoted are skipped.
     """
+    if source_state is None:
+        source_state = SourceStateStore()
+
     promote: list[str] = []
     demote: list[str] = []
 
@@ -288,7 +386,10 @@ def evaluate_trial_sources(
     for source in sources:
         if not source.trial:
             continue
-        if source.trial_started is None:
+        if source_state.is_graduated(source.name) or source_state.is_demoted(source.name):
+            continue
+        trial_started = source_state.get_trial_started(source.name)
+        if trial_started is None:
             logger.info(
                 "Trial source '%s' has no trial_started date; will initialize to %s",
                 source.name,
@@ -297,14 +398,14 @@ def evaluate_trial_sources(
             needs_start.append(source.name)
             continue
         try:
-            started_dt = datetime.strptime(source.trial_started, "%Y-%m-%d").replace(
+            started_dt = datetime.strptime(trial_started, "%Y-%m-%d").replace(
                 tzinfo=timezone.utc
             )
         except ValueError:
             logger.warning(
                 "Invalid trial_started date for source '%s': %s",
                 source.name,
-                source.trial_started,
+                trial_started,
             )
             continue
 
@@ -321,145 +422,28 @@ def evaluate_trial_sources(
     return promote, demote, needs_start
 
 
-def _find_source_block(lines: list[str], source_name: str) -> tuple[int, int] | None:
-    """Find the line range [start, end) of a source entry with the given name."""
-    i = 0
-    while i < len(lines):
-        match = re.match(r"^(\s*)-\s+\w+\s*:", lines[i])
-        if match:
-            indent = len(match.group(1))
-            start = i
-            end = i + 1
-            while end < len(lines):
-                stripped = lines[end]
-                if stripped.strip() == "" or stripped.lstrip().startswith("#"):
-                    end += 1
-                    continue
-                next_match = re.match(r"^(\s*)-\s+\S", stripped)
-                if next_match and len(next_match.group(1)) <= indent:
-                    break
-                key_match = re.match(r"^(\s*)\S", stripped)
-                if key_match and len(key_match.group(1)) <= indent:
-                    break
-                end += 1
-
-            for k in range(start, end):
-                name_match = re.match(r"^\s*-?\s*name:\s*(.+?)\s*$", lines[k])
-                if name_match and name_match.group(1).strip("\"'") == source_name:
-                    return start, end
-
-            i = end
-        else:
-            i += 1
-    return None
-
-
-def _set_field_in_block(
-    lines: list[str], start: int, end: int, field_name: str, value: str
-) -> list[str]:
-    """Set or add a YAML field within a source block (lines[start:end])."""
-    field_indent = "    "
-    for k in range(start + 1, end):
-        m = re.match(r"^(\s+)\w", lines[k])
-        if m:
-            field_indent = m.group(1)
-            break
-
-    for k in range(start, end):
-        pattern = rf"^(\s+){re.escape(field_name)}\s*:.*$"
-        if re.match(pattern, lines[k]):
-            lines[k] = f"{field_indent}{field_name}: {value}"
-            return lines
-
-    lines.insert(end, f"{field_indent}{field_name}: {value}")
-    return lines
-
-
-def _remove_field_in_block(
-    lines: list[str], start: int, end: int, field_name: str
-) -> tuple[list[str], int]:
-    """Remove a YAML field line from a source block. Returns updated lines and new end."""
-    for k in range(start, end):
-        if re.match(rf"^\s+{re.escape(field_name)}\s*:.*$", lines[k]):
-            lines.pop(k)
-            return lines, end - 1
-    return lines, end
-
-
-def apply_trial_decisions(
-    config_path: str,
+def apply_trial_decisions_to_cache(
+    store: SourceStateStore,
     promote: list[str],
     demote: list[str],
+    today: str,
     needs_start: list[str] | None = None,
-) -> None:
-    """Update config.yaml: set trial=false for promoted, enabled=false for demoted,
-    and initialize trial_started for new trial sources.
+) -> SourceStateStore:
+    """Apply trial promotion/demotion decisions to the source state cache.
+
+    Graduated sources: mark_graduated (trial_started cleared).
+    Demoted sources: mark_demoted.
+    needs_start sources: initialize trial_started to today.
     """
     if needs_start is None:
         needs_start = []
-    if not promote and not demote and not needs_start:
-        return
-
-    path = Path(config_path)
-    with path.open("r", encoding="utf-8") as fh:
-        lines = fh.read().splitlines()
-
-    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-
     for name in promote:
-        block = _find_source_block(lines, name)
-        if block is None:
-            logger.warning("Cannot find source '%s' in config for promotion", name)
-            continue
-        start, end = block
-        lines = _set_field_in_block(lines, start, end, "trial", "false")
-        block = _find_source_block(lines, name)
-        if block:
-            start, end = block
-            lines, end = _remove_field_in_block(lines, start, end, "trial_started")
-            lines, end = _remove_field_in_block(lines, start, end, "trial_days")
-        logger.info("Promoted trial source '%s' to permanent", name)
-
+        store.mark_graduated(name)
+        logger.info("Graduated trial source '%s' to permanent", name)
     for name in demote:
-        block = _find_source_block(lines, name)
-        if block is None:
-            logger.warning("Cannot find source '%s' in config for demotion", name)
-            continue
-        start, end = block
-        lines = _set_field_in_block(lines, start, end, "enabled", "false")
-        logger.info("Demoted trial source '%s' (disabled)", name)
-
+        store.mark_demoted(name)
+        logger.info("Demoted trial source '%s'", name)
     for name in needs_start:
-        block = _find_source_block(lines, name)
-        if block is None:
-            logger.warning("Cannot find source '%s' in config to set trial_started", name)
-            continue
-        start, end = block
-        lines = _set_field_in_block(lines, start, end, "trial_started", today)
+        store.set_trial_started(name, today)
         logger.info("Initialized trial_started for '%s' to %s", name, today)
-
-    bak_path = path.with_suffix(".yaml.bak")
-    tmp_path = path.with_suffix(".yaml.tmp")
-    try:
-        shutil.copy2(path, bak_path)
-    except OSError as exc:
-        logger.error("Cannot create config backup, aborting trial decisions: %s", exc)
-        return
-
-    try:
-        with tmp_path.open("w", encoding="utf-8") as fh:
-            fh.write("\n".join(lines))
-            if lines:
-                fh.write("\n")
-        tmp_path.replace(path)
-        if bak_path is not None and bak_path.exists():
-            bak_path.unlink(missing_ok=True)
-    except Exception:
-        if tmp_path.exists():
-            tmp_path.unlink(missing_ok=True)
-        if bak_path is not None and bak_path.exists():
-            logger.error(
-                "config.yaml write failed — backup preserved at '%s' for manual recovery.",
-                bak_path,
-            )
-        raise
+    return store

--- a/plan.md
+++ b/plan.md
@@ -1,125 +1,152 @@
-# Plan: Engine-instance split (Issue #31)
+# Plan: Issue #37 — Consolidate Source state (eliminate dual-storage split)
 
 ## 1. Problem restatement
 
-The `digest` repository currently acts as three things at once: a Python codebase with tests and CI, a private configuration store with personal RSS sources and LLM weights, and a production runtime that commits generated digests and cache state back to `main` via GitHub Actions. These roles have incompatible hygiene requirements — code wants a clean PR-only history, config wants to be private, and runtime state wants to be committed every two hours. The goal is to split the repo into `digest` (public engine — code only) and `digest-prod` (private instance — config, state, workflows), as decided in ADR-0002.
+`digest/source_scorer.py:389–465` содержит функцию `apply_trial_decisions()`, которая мутирует `config.yaml` во время рантайма через regex-манипуляцию строк YAML (`_find_source_block`, `_set_field_in_block`, `_remove_field_in_block`). Это делает `config.yaml` одновременно human-edited декларацией намерения и хранилищем мутируемого рантайм-состояния. Нарушение инварианта имеет три проявления: (1) любой ручной git diff в `digest-prod` может конфликтовать с автоматической записью на следующем cron; (2) движок требует `config_path` writable, что нарушает ADR-0002 контракт; (3) round-trip property тест (acceptance criterion) невозможен, пока state и config — один файл.
 
 ## 2. Affected bounded contexts and files
 
-No domain docs exist; bounded contexts are inferred from module structure.
+**Bounded Context: Digest** (единственный BC; domain overview `docs/domain/digest/overview.md`)
 
-**Engine (digest) — changes required:**
+Затронутые агрегаты по domain overview:
+- **Source** (Yellow aggregate) — владеет `trial_state` как value object; сейчас персистирует его через regex в config.yaml; после изменения — через `SourceStateStore` в `.cache/source_state.json`
 
-| File / path | Change |
-|---|---|
-| `src/` (entire directory) | Rename to `digest/` |
-| All `from src.X` imports (112 occurrences across 40 files) | → `from digest.X` |
-| `src/__main__.py` docstring and import | `from src.main` → `from digest.main` |
-| `pyproject.toml` | **`[project] name = "daily-digest"` → `"digest"`** (distribution name — must match `pip install "digest @ git+..."`); package discovery `src` → `digest`; **drop `[project.scripts]`** (workflows use `python -m digest`, no script entry point needed); `known-first-party = ["digest"]`; `--cov=digest` |
-| `Makefile` | `ruff check src/` → `ruff check digest/`; `mypy src/` → `mypy digest/` |
-| `.pre-commit-config.yaml` | `args: [-r, src/` → `args: [-r, digest/` |
-| `.github/workflows/ci.yml` | `python -m src` → `python -m digest`; remove config-validate step (config.yaml no longer in engine repo) |
-| `.github/workflows/daily.yml` | Remove entirely (moves to digest-prod) |
-| `.github/workflows/discover.yml` | Remove entirely (moves to digest-prod) |
-| `config.yaml` | Remove from engine repo (moves to digest-prod) |
-| `.cache/` | Remove from engine repo (moves to digest-prod) |
-| `digests/` | Remove from engine repo (moves to digest-prod) |
-| `README.md` | Update architecture section, installation instructions |
-| `CLAUDE.md` | Update project structure, entry point |
-| `.gitignore` | Add `config.yaml`, `.cache/`, `digests/` (protect against accidental re-add) |
-| `pyproject.toml` `[tool.mypy]` | `python_version` stays 3.12 |
+Файлы:
 
-**Instance (digest-prod) — new repo:**
-
-| File / path | Action |
-|---|---|
-| `config.yaml` | Copy from engine (current) |
-| `.cache/` | Copy from engine (current) |
-| `digests/` | Copy from engine (current) |
-| `.github/workflows/daily.yml` | Adapt: replace `pip install -r requirements.txt` with `pip install "digest @ git+https://github.com/Lenivvenil/digest@main"`; remove `test` job |
-| `.github/workflows/discover.yml` | Same adaptation |
-| `requirements.txt` | `digest @ git+https://github.com/Lenivvenil/digest@main` |
-| GitHub Secrets | Re-create all 7 secrets in digest-prod |
-| `.gitignore` | Standard Python |
+| Файл | Тип изменения |
+|------|--------------|
+| `digest/source_scorer.py` | Крупная переработка: новые `SourceStateEntry`, `SourceStateStore`, `load_source_state()`, `save_source_state()`, `apply_trial_decisions_to_cache()`; удаление `apply_trial_decisions()`, `_find_source_block()`, `_set_field_in_block()`, `_remove_field_in_block()` |
+| `digest/source_scorer.py:evaluate_trial_sources()` | Смена сигнатуры: принимает `SourceStateStore` вместо читки `source.trial_started` из `SourceConfig` |
+| `digest/config.py` | `SourceConfig`: удалить поле `trial_started`; добавить метод `Config.effective_sources(source_state)` |
+| `digest/main.py` | Загрузка/сохранение `SourceStateStore`; замена `apply_trial_decisions()` на `apply_trial_decisions_to_cache()`; замена `config.enabled_sources` на `config.effective_sources(source_state)` в adaptive-ветке |
+| `tests/test_source_scorer.py` | Удалить тесты YAML-хелперов и `apply_trial_decisions`; добавить тесты SourceStateStore CRUD, round-trip, `apply_trial_decisions_to_cache` |
+| `tests/test_source_state_roundtrip.py` | Новый файл — property round-trip тест (acceptance criterion) |
+| `tests/test_config.py` | Убрать `trial_started` из fixture-данных источников |
+| `tests/test_main.py` | Обновить mocking: вместо патча `apply_trial_decisions` — патч cache-операций |
 
 ## 3. Considered approaches
 
-### Approach A — Rename-then-split (chosen)
+### Approach A — Merge at load time
 
-Rename `src/` → `digest/` in the engine repo first, run tests to confirm, then create `digest-prod` and configure it to `pip install` from engine. The config.yaml mutation problem (trial dates, `enabled: false`) is **not refactored** — config.yaml moves wholesale to `digest-prod` where it can still be mutated freely by `apply_trial_decisions()` and `add_trial_source()`. The dual-nature concern from the issue body only matters if config.yaml needs to live in *both* repos; with it living only in `digest-prod`, mutation is isolated and fine.
-
-**Trade-offs:**
-- Pro: minimal scope — no data model changes, no new cache files, no changes to how `apply_trial_decisions` works
-- Pro: tests continue to pass without mocking config writes (tests use `tmp_path` fixtures already)
-- Con: config.yaml in `digest-prod` is still a mix of static preferences and runtime state — acknowledged but not worse than today
-- Con: `pip install git+...@main` means engine's `main` is always the prod version — no pinning; a bad commit can break prod on the next cron run
-
-### Approach B — Extract dynamic state before split
-
-Before splitting, refactor `apply_trial_decisions()` and `add_trial_source()` to write trial metadata and `enabled` flags to `.cache/dynamic_sources.json` instead of `config.yaml`. `config.yaml` becomes truly static.
+`load_config()` принимает опциональный `source_state: SourceStateStore | None` и при загрузке применяет overrides к `SourceConfig.enabled` на основе `demoted` флага.
 
 **Trade-offs:**
-- Pro: clean separation — `config.yaml` is pure user intent, `.cache/` is pure runtime state
-- Pro: makes it possible to later version-control config.yaml separately without worrying about runtime mutations
-- Con: scope creep — changes `source_scorer.py`, `discovery.py`, `config.py` and all their tests before the split even starts; doubles implementation risk
-- Con: not required by ADR-0002; the ADR decision is about repo topology, not data model
+- ✓ Единое место merge — весь downstream код видит уже "правильные" источники через `config.enabled_sources`
+- ✗ `config.py` получает зависимость от cache-типов из `source_scorer.py` → circular import риск (source_scorer уже импортирует `SourceConfig` из config.py)
+- ✗ Нарушает принцип разделения ответственностей: config-loader не должен знать о runtime overrides
 
-**Verdict:** Approach A now, Approach B as a separate issue later if the dual-nature of config.yaml becomes a real operational problem.
+### Approach B — Метод `Config.effective_sources(source_state)` (ADR-0003)
 
-### Approach C — Pin engine to a git tag (variant of A)
-
-Same as A but `requirements.txt` in `digest-prod` pins to a released tag (`digest @ git+...@v2.0.0`) instead of `@main`.
+`config.py` остаётся чистым loader'ом без знания о cache. Добавляется метод `Config.effective_sources(source_state: SourceStateStore) -> list[SourceConfig]`, который фильтрует demoted источники. Runtime-код в `main.py` использует этот метод вместо `config.enabled_sources` в adaptive-ветке.
 
 **Trade-offs:**
-- Pro: prod stability — a bad commit in engine doesn't break prod until explicitly bumped
-- Con: requires a release discipline (tag before prod can get new code); solo developer overhead
-- Con: ADR-0002 Re-visit Trigger #2 already covers the case where release-contract fails; for now `@main` is simpler
-
-**Verdict:** Start with `@main`, upgrade to tag-pinning when/if Re-visit Trigger #2 fires.
+- ✓ Нет circular import — `Config` не знает о `SourceStateStore`
+- ✓ `config.enabled_sources` остаётся работающим для non-adaptive flow и тестов без state
+- ✓ Merge-семантика явна: `demoted` из cache + `enabled` из config → effective list
+- ✗ Два метода (`enabled_sources` и `effective_sources`) — вызывающий должен знать, какой использовать; документировать в docstring
 
 ## 4. Chosen approach and why
 
-**Approach A** (rename-then-split, `@main` pin).
+**Approach B**, per ADR-0003 (Option B — Full state split), `docs/decisions/0003-source-state-split.md`.
 
-ADR-0002 chose the two-repo split to solve repo topology, not data model. Approach A implements exactly that decision without adding scope. The 112 import rewrites are mechanical and fully covered by `ruff check` + `mypy` + existing test suite. The config.yaml mutation concern is a latent issue regardless of approach — it's better addressed as a focused follow-up than as a prerequisite that blocks the split.
+ADR зафиксировал: только Option B (и A') полностью закрывают инвариант config.yaml read-only. Между ними B выбран из-за наличия `schema_version` (защита от schema drift) и паттерна FeedbackStore (консистентность с существующим cache-механизмом).
 
-Relevant ADRs: ADR-0002 (engine-instance split), ADR-0001 (governance — commit-msg hook will run on the rename PR).
+**Conflict resolution** (из ADR-0003 Bootstrap section): config wins для declarations; cache wins для outcomes. При конфликте (`enabled: true` в config + `demoted: true` в cache) — cache outcome применяется.
+
+**Конкретные изменения:**
+
+```
+SourceConfig:
+  - trial_started  ← удалить
+
+SourceStateEntry (новый dataclass):
+  + trial_started: str | None = None
+  + graduated: bool = False
+  + demoted: bool = False
+
+SourceStateStore (новый dataclass):
+  + schema_version: int = 1
+  + sources: dict[str, SourceStateEntry] = field(default_factory=dict)
+  + методы: is_demoted(name), is_graduated(name), get_trial_started(name), set_trial_started(name, date), mark_graduated(name), mark_demoted(name)
+
+Config (обновить):
+  + effective_sources(source_state: SourceStateStore) -> list[SourceConfig]
+    — возвращает источники, где enabled=True И NOT source_state.is_demoted(name)
+
+source_scorer.py изменения:
+  apply_trial_decisions()         → удалить (вместе с YAML-хелперами)
+  _find_source_block()            → удалить
+  _set_field_in_block()           → удалить
+  _remove_field_in_block()        → удалить
+  evaluate_trial_sources()        → принимает source_state: SourceStateStore
+                                     источник считается "в испытании" только если:
+                                     source.trial==True AND NOT is_graduated(name) AND NOT is_demoted(name)
+  apply_trial_decisions_to_cache() → новая функция, мутирует SourceStateStore
+  load_source_state(cache_dir)    → новая функция
+  save_source_state(store, cache_dir) → новая функция, atomic_json_write
+
+main.py изменения:
+  + source_state = load_source_state(cache_dir)
+  evaluate_trial_sources(...) ← добавить source_state аргумент
+  apply_trial_decisions(...) → apply_trial_decisions_to_cache(source_state, promote, demote, needs_start, today)
+  + save_source_state(source_state, cache_dir)
+  config.enabled_sources → config.effective_sources(source_state) в adaptive-ветке evaluate
+```
 
 ## 5. Test strategy
 
-**Unit (existing, unchanged):** All 83 tests in `tests/` cover the production code. After renaming `src/` → `digest/`, every `from src.X import Y` becomes `from digest.X import Y`. If any import is missed, pytest will fail with `ModuleNotFoundError` — full coverage of the rename.
+### Unit tests (обновление `tests/test_source_scorer.py`)
 
-**Assertions that matter:**
-- `pytest tests/ -v` passes 83/83 after rename
-- `ruff check digest/ tests/` clean (catches missed `src` references in imports)
-- `mypy digest/` clean
-- `python -m digest --help` exits 0 (verifies entry point wiring)
-- `python -c "from digest.config import load_config"` exits 0
+Удалить:
+- `test_find_source_block_*` (3 теста) — функция удаляется
+- `test_set_field_in_block_*` (2 теста) — функция удаляется
+- `test_remove_field_in_block*` (2 теста) — функция удаляется
+- все `test_apply_trial_decisions_*` — функция удаляется
 
-**Integration (manual, async):** After `digest-prod` is configured:
-- Trigger `daily.yml` via `workflow_dispatch` in `digest-prod`
-- Observe successful `digest: YYYY-MM-DD` commit in `digest-prod/main`
+Добавить:
+- `test_load_source_state_missing_file` — возвращает пустой SourceStateStore
+- `test_load_source_state_corrupted_json` — graceful degradation
+- `test_load_source_state_unknown_schema_version` — warning + start fresh
+- `test_source_state_store_roundtrip` — save → load → equality
+- `test_apply_trial_decisions_to_cache_promote` — graduated=True, trial_started=None
+- `test_apply_trial_decisions_to_cache_demote` — demoted=True
+- `test_apply_trial_decisions_to_cache_needs_start` — инициализирует trial_started в store
+- `test_evaluate_trial_sources_reads_from_state` — trial_started из SourceStateStore, не SourceConfig
+- `test_evaluate_trial_sources_skips_graduated` — config trial=True + cache graduated=True → source не в needs_start, не в promote, не в demote (без этого graduated source зацикливается обратно в trial)
 
-**No new tests needed** — the rename is structural, not behavioral.
+### Round-trip property test (новый файл `tests/test_source_state_roundtrip.py`)
+
+Acceptance criterion #37: загрузить config + пустой cache → выставить `trial_started` в SourceStateStore → сохранить cache → перезагрузить → значение совпадает. Тест работает на `tmp_path`, без реального `config.yaml`.
+
+### Обновление `tests/test_config.py`
+
+- Убрать `trial_started` из всех fixture-dict источников
+- Добавить `test_config_effective_sources_filters_demoted`
+
+### Обновление `tests/test_main.py`
+
+- Заменить `patch("digest.source_scorer.apply_trial_decisions")` → `patch("digest.source_scorer.apply_trial_decisions_to_cache")`
+- Добавить патчи для `load_source_state` / `save_source_state`
+
+### Coverage target
+
+≥ 70% (текущий floor в `pyproject.toml`). Удаляемые тесты заменяются по объёму.
 
 ## 6. Risks and unknowns
 
-- **pip install from GitHub in CI:** `pip install "digest @ git+https://github.com/Lenivvenil/digest@main"` requires the engine repo to be public OR a deploy key/PAT to be configured in `digest-prod`. If engine stays private during transition, the `git+https` install will fail with 401. **Mitigation:** make engine repo public before configuring `digest-prod` workflows, or add a PAT secret.
+1. **`enabled_sources` vs `effective_sources` call sites** — в non-adaptive flow `enabled_sources` корректен. Риск: в adaptive flow пропустить место и demoted source попадёт в пайплайн. **Mitigation:** grep `enabled_sources` перед commit.
 
-- **`pyproject.toml` package discovery:** currently there is no explicit `[tool.setuptools.packages.find]` — pip/setuptools auto-discovers packages. After renaming `src/` → `digest/`, auto-discovery should find `digest/` as a top-level package. But if `pyproject.toml` has any implicit `src` references in build config, the install will silently produce an empty package. **Mitigation:** test `pip install -e .` locally before creating `digest-prod`.
+2. **`evaluate_trial_sources` signature change** — читает `source.trial_started` из `SourceConfig` сейчас. Все callers — только `main.py:719`. mypy strict поймает несовместимость.
 
-- **`.cache/` and `digests/` migration:** current `.cache/` contains live state (seen articles, feedback, source stats, pending sources). Copying to `digest-prod` preserves continuity — no articles will be re-sent. However, if the copy is stale (committed state is from last cron run, not current), the first run in `digest-prod` will miss any feedback collected in the gap. Acceptable.
+3. **`_process_pending_approvals` в `main.py:715`** — ✅ Проверено. Вызывает `add_source_to_config()` из `discovery.py:135` — добавляет новый одобренный пользователем источник. Это прокси для ручного действия, не trial state mutation. **Вне scope #37.** После этого PR config.yaml всё ещё пишется discovery-флоу. Отразить как known limitation в PR description.
 
-- **GitHub Secrets migration:** 7 secrets must be re-created manually in `digest-prod`. There is no automated way to copy secrets between repos. Risk of typo or missed secret = first prod run silently fails. **Mitigation:** run `workflow_dispatch` and check logs immediately after setup.
+4. **`trial_started` migration в `digest-prod`** — вне scope. Существующие источники с `trial_started` в `config.yaml` при первом запуске увидят `None` в cache — trial clock сбросится. Предупреждение в CHANGELOG.
 
-- **Commit-msg governance hook (ADR-0001):** the hook runs on `git commit` in the engine repo. The rename commit will be a large mechanical change — governance hook checks commit type prefix (`feat/fix/chore/adr/...`). Use `chore:` prefix. No conflict.
+5. **mypy strict** — все новые dataclass-методы требуют полных annotations; `field(default_factory=dict)` для dict-поля.
 
-- **`digests/` git history:** after removing `digests/` from engine repo, the history of digest files remains in `git log`. This is expected and acceptable — the history is not deleted, just not tracked going forward.
+6. **Четвёртый cache-файл** — graceful degradation обязателен. Копировать паттерн дословно из `feedback.py:42–79`.
 
-- **`python-version` drift:** `.mise.toml` pins Python 3.13 locally; CI uses 3.12. The rename is compatible with both. No change needed in this plan; tracking it as a known latent issue.
+---
 
-## Execution order
-
-1. **PR 1 (engine):** rename `src/` → `digest/`, update all imports and infra files (`pyproject.toml`, `Makefile`, `.pre-commit-config.yaml`, `ci.yml`), strip `daily.yml`/`discover.yml`/`config.yaml`/`.cache/`/`digests/`, update README + CLAUDE.md. Tests pass. Merge.
-2. **Make `digest` repo public** — required before step 3 so `pip install "digest @ git+https://github.com/Lenivvenil/digest@main"` works without a PAT. This is the simplest option; engine has no secrets or private data after step 1.
-3. **Create `Lenivvenil/digest-prod`** (private), copy files, configure secrets, adapt workflows, trigger `workflow_dispatch` to verify pipeline.
+*Closes #37*
+*Implements docs/decisions/0003-source-state-split.md*

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -460,3 +460,44 @@ def test_non_mapping_yaml(tmp_path: Path) -> None:
     cfg_path.write_text("- item1\n- item2\n", encoding="utf-8")
     with pytest.raises(ValueError, match="mapping"):
         load_config(str(cfg_path))
+
+
+def test_effective_sources_filters_demoted(tmp_path: Path) -> None:
+    """Config.effective_sources excludes sources marked demoted in cache."""
+    from digest.source_scorer import SourceStateStore
+
+    cfg_path = _write_config(tmp_path, """
+        llm:
+          providers:
+            - name: groq
+              model: llama-3.3-70b-versatile
+              role: [summarize]
+        sources:
+          - name: GoodFeed
+            url: https://example.com/feed
+            category: Test
+            enabled: true
+          - name: DemotedFeed
+            url: https://example.com/other
+            category: Test
+            enabled: true
+    """)
+    config = load_config(cfg_path)
+
+    store = SourceStateStore()
+    store.mark_demoted("DemotedFeed")
+
+    effective = config.effective_sources(store)
+    assert len(effective) == 1
+    assert effective[0].name == "GoodFeed"
+
+
+def test_effective_sources_empty_state_same_as_enabled(tmp_path: Path) -> None:
+    """With empty cache, effective_sources equals enabled_sources."""
+    from digest.source_scorer import SourceStateStore
+
+    cfg_path = _write_config(tmp_path, MINIMAL_CONFIG)
+    config = load_config(cfg_path)
+
+    store = SourceStateStore()
+    assert config.effective_sources(store) == config.enabled_sources

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -77,7 +77,7 @@ def test_save_and_load_pending_round_trip(tmp_path: Path) -> None:
         name="The New Stack",
         url="https://thenewstack.io/feed/",
         category="Cloud & Infrastructure",
-        discovered_at="2026-03-27T10:00:00+00:00",
+        discovered_at=datetime.now(tz=timezone.utc).isoformat(),
     )
     save_pending([ps], str(tmp_path))
     loaded = load_pending(str(tmp_path))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,7 +79,6 @@ class _SourceCfg:
     priority: int = 3
     recency_hours: int = 24
     trial: bool = False
-    trial_started: str | None = None
     trial_days: int = 7
 
 

--- a/tests/test_source_scorer.py
+++ b/tests/test_source_scorer.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
-import yaml
-
 from digest.config import AdaptiveConfig, SourceConfig
 from digest.source_scorer import (
     DailySnapshot,
+    SourceStateStore,
     SourceStats,
-    apply_trial_decisions,
+    apply_trial_decisions_to_cache,
     calculate_effective_priorities,
     calculate_score,
     detect_trending_sources,
     evaluate_trial_sources,
+    load_source_state,
     load_stats,
+    save_source_state,
     save_stats,
     update_stats,
 )
@@ -442,19 +443,23 @@ def test_effective_priorities_trend_bonus_capped_at_min() -> None:
 # --- evaluate_trial_sources ---
 
 
-def _make_trial_source(
-    name: str, trial_started: str, trial_days: int = 7
-) -> SourceConfig:
+def _make_trial_source(name: str, trial_days: int = 7) -> SourceConfig:
     return SourceConfig(
         name=name, url="https://x.com", category="Tech",
-        enabled=True, priority=3, trial=True,
-        trial_started=trial_started, trial_days=trial_days,
+        enabled=True, priority=3, trial=True, trial_days=trial_days,
     )
+
+
+def _state_with_started(name: str, trial_started: str) -> SourceStateStore:
+    store = SourceStateStore()
+    store.set_trial_started(name, trial_started)
+    return store
 
 
 def test_evaluate_trial_not_expired() -> None:
     """Trial source not yet past trial_days should not be promoted or demoted."""
-    sources = [_make_trial_source("New", trial_started="2026-03-15", trial_days=7)]
+    sources = [_make_trial_source("New", trial_days=7)]
+    state = _state_with_started("New", "2026-03-15")
     today = "2026-03-18"  # only 3 days elapsed
     stats = {
         "New": SourceStats(
@@ -463,7 +468,7 @@ def test_evaluate_trial_not_expired() -> None:
             avg_description_length=200.0, last_seen="2026-03-18",
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert promote == []
     assert demote == []
     assert needs_start == []
@@ -471,7 +476,8 @@ def test_evaluate_trial_not_expired() -> None:
 
 def test_evaluate_trial_promote_high_score() -> None:
     """Expired trial with high score (>0.6) should be promoted."""
-    sources = [_make_trial_source("Good", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("Good", trial_days=7)]
+    state = _state_with_started("Good", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "Good": SourceStats(
@@ -480,7 +486,7 @@ def test_evaluate_trial_promote_high_score() -> None:
             avg_description_length=200.0, last_seen=today,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert "Good" in promote
     assert demote == []
     assert needs_start == []
@@ -488,7 +494,8 @@ def test_evaluate_trial_promote_high_score() -> None:
 
 def test_evaluate_trial_demote_low_score() -> None:
     """Expired trial with low score (<0.3) should be demoted."""
-    sources = [_make_trial_source("Bad", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("Bad", trial_days=7)]
+    state = _state_with_started("Bad", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "Bad": SourceStats(
@@ -497,7 +504,7 @@ def test_evaluate_trial_demote_low_score() -> None:
             avg_description_length=10.0, last_seen=None,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert promote == []
     assert "Bad" in demote
     assert needs_start == []
@@ -505,7 +512,8 @@ def test_evaluate_trial_demote_low_score() -> None:
 
 def test_evaluate_trial_middling_score_no_action() -> None:
     """Expired trial with score between 0.3 and 0.6 stays in trial."""
-    sources = [_make_trial_source("Mid", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("Mid", trial_days=7)]
+    state = _state_with_started("Mid", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "Mid": SourceStats(
@@ -514,7 +522,7 @@ def test_evaluate_trial_middling_score_no_action() -> None:
             avg_description_length=80.0, last_seen=today,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert promote == []
     assert demote == []
     assert needs_start == []
@@ -530,8 +538,9 @@ def test_evaluate_trial_non_trial_ignored() -> None:
 
 
 def test_evaluate_trial_invalid_date_format() -> None:
-    """Trial source with invalid trial_started date should be skipped with warning."""
-    sources = [_make_trial_source("BadDate", trial_started="2026/03/01", trial_days=7)]
+    """Trial source with invalid trial_started date in state should be skipped."""
+    sources = [_make_trial_source("BadDate", trial_days=7)]
+    state = _state_with_started("BadDate", "2026/03/01")  # invalid format in cache
     today = "2026-03-18"
     stats = {
         "BadDate": SourceStats(
@@ -540,8 +549,7 @@ def test_evaluate_trial_invalid_date_format() -> None:
             avg_description_length=200.0, last_seen=today,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
-    # Source with invalid date should be skipped entirely
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert promote == []
     assert demote == []
     assert needs_start == []
@@ -549,16 +557,9 @@ def test_evaluate_trial_invalid_date_format() -> None:
 
 def test_evaluate_trial_boundary_just_below_0_6_not_promoted() -> None:
     """Trial source with score just below 0.6 should NOT be promoted (threshold is > 0.6)."""
-    sources = [_make_trial_source("NotQuite", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("NotQuite", trial_days=7)]
+    state = _state_with_started("NotQuite", "2026-03-01")
     today = "2026-03-18"
-    # Create stats that give a score just below 0.6
-    # score = reliability*0.3 + productivity*0.3 + desc*0.2 + recency*0.2
-    # For score = 0.59: 0.5*0.3 + 0.5*0.3 + 0.5*0.2 + 0.5*0.2 = 0.5
-    # Need higher: 1.0*0.3 + 0.5*0.3 + 0.6*0.2 + 1.0*0.2 = 0.3+0.15+0.12+0.2 = 0.77
-    # Need to find values that equal ~0.59
-    # 1.0*0.3 + 0.3*0.3 + 0.96*0.2 + 1.0*0.2 = 0.3+0.09+0.192+0.2 = 0.782
-    # Try: 0.8*0.3 + 0.375*0.3 + 0.75*0.2 + 1.0*0.2 = 0.24+0.1125+0.15+0.2 = 0.7025
-    # Try: 0.5*0.3 + 0.3*0.3 + 0.5*0.2 + 1.0*0.2 = 0.15+0.09+0.1+0.2 = 0.54 (good, below 0.6)
     stats = {
         "NotQuite": SourceStats(
             name="NotQuite",
@@ -566,18 +567,18 @@ def test_evaluate_trial_boundary_just_below_0_6_not_promoted() -> None:
             successful_fetches=5,  # reliability = 0.5
             total_articles_found=10,
             articles_included_in_digest=3,  # productivity = 0.3
-            avg_description_length=60.0,  # desc = (60-20)/(200-20) = 0.5
+            avg_description_length=60.0,
             last_seen=today,  # recency = 1.0
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
-    # Score should be ~0.54, which is < 0.6, so NOT promoted
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert "NotQuite" not in promote
 
 
 def test_evaluate_trial_boundary_just_above_0_6_promoted() -> None:
     """Trial source with score just above 0.6 should be promoted."""
-    sources = [_make_trial_source("JustGood", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("JustGood", trial_days=7)]
+    state = _state_with_started("JustGood", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "JustGood": SourceStats(
@@ -586,14 +587,14 @@ def test_evaluate_trial_boundary_just_above_0_6_promoted() -> None:
             avg_description_length=150.0, last_seen=today,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
-    # This should have score > 0.6
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert "JustGood" in promote
 
 
 def test_evaluate_trial_boundary_just_above_0_3_not_demoted() -> None:
     """Trial source with score just above 0.3 should NOT be demoted (threshold is < 0.3)."""
-    sources = [_make_trial_source("Middling", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("Middling", trial_days=7)]
+    state = _state_with_started("Middling", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "Middling": SourceStats(
@@ -604,22 +605,20 @@ def test_evaluate_trial_boundary_just_above_0_3_not_demoted() -> None:
             articles_included_in_digest=5,
             avg_description_length=20.0,
             last_seen=None,  # recency = 0.0
-            # 7 snaps with 50% inclusion → productivity = 0.5
             history=[
                 DailySnapshot(date=f"2026-03-{i:02d}", articles_found=2, articles_included=1, fetch_ok=True)
                 for i in range(1, 8)
             ],
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
-    # score = 0.5*0.3 + 0.5*0.3 + 0.2*0.2 + 0.0*0.2 = 0.34
-    # Above 0.3, should NOT be demoted (threshold is < 0.3)
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert "Middling" not in demote
 
 
 def test_evaluate_trial_boundary_just_below_0_3_demoted() -> None:
     """Trial source with score just below 0.3 should be demoted."""
-    sources = [_make_trial_source("JustBad", trial_started="2026-03-01", trial_days=7)]
+    sources = [_make_trial_source("JustBad", trial_days=7)]
+    state = _state_with_started("JustBad", "2026-03-01")
     today = "2026-03-18"
     stats = {
         "JustBad": SourceStats(
@@ -628,311 +627,124 @@ def test_evaluate_trial_boundary_just_below_0_3_demoted() -> None:
             avg_description_length=10.0, last_seen=None,
         )
     }
-    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today)
-    # This should have score < 0.3
+    promote, demote, needs_start = evaluate_trial_sources(sources, stats, today, state)
     assert "JustBad" in demote
 
 
-# --- YAML manipulation helpers (_find_source_block, _set_field_in_block, _remove_field_in_block) ---
+# --- SourceStateStore and apply_trial_decisions_to_cache ---
 
 
-def test_find_source_block_first_key_name() -> None:
-    """Find source block when name is the first key."""
-    from digest.source_scorer import _find_source_block
-
-    lines = [
-        "sources:",
-        "  - name: Feed1",
-        "    url: https://example.com",
-        "    category: Tech",
-        "  - name: Feed2",
-        "    url: https://other.com",
-    ]
-    start, end = _find_source_block(lines, "Feed1")
-    assert start == 1
-    assert end == 4  # Up to the next list item
+def test_load_source_state_missing_file(tmp_path: Path) -> None:
+    """load_source_state returns empty store when file does not exist."""
+    store = load_source_state(str(tmp_path))
+    assert isinstance(store, SourceStateStore)
+    assert store.sources == {}
 
 
-def test_find_source_block_name_later_key() -> None:
-    """Find source block when name appears after other keys (alphabetical order)."""
-    from digest.source_scorer import _find_source_block
-
-    lines = [
-        "sources:",
-        "  - category: Tech",
-        "    name: Feed1",
-        "    url: https://example.com",
-        "  - category: News",
-        "    name: Feed2",
-    ]
-    start, end = _find_source_block(lines, "Feed1")
-    assert start == 1
-    assert end == 4
+def test_load_source_state_corrupted_json(tmp_path: Path) -> None:
+    """load_source_state returns empty store on corrupt JSON."""
+    (tmp_path / "source_state.json").write_text("not valid json", encoding="utf-8")
+    store = load_source_state(str(tmp_path))
+    assert store.sources == {}
 
 
-def test_find_source_block_nonexistent() -> None:
-    """Find source block returns None when source not found."""
-    from digest.source_scorer import _find_source_block
-
-    lines = [
-        "sources:",
-        "  - name: Feed1",
-        "    url: https://example.com",
-    ]
-    result = _find_source_block(lines, "NonExistent")
-    assert result is None
+def test_load_source_state_unknown_schema_version(tmp_path: Path) -> None:
+    """load_source_state returns empty store when schema_version is unknown."""
+    (tmp_path / "source_state.json").write_text('{"schema_version": 99, "sources": {}}', encoding="utf-8")
+    store = load_source_state(str(tmp_path))
+    assert store.sources == {}
 
 
-def test_set_field_in_block_replaces_existing() -> None:
-    """Set field should replace existing value."""
-    from digest.source_scorer import _set_field_in_block
-
-    lines = [
-        "  - name: Feed1",
-        "    trial: true",
-        "    url: https://example.com",
-    ]
-    result = _set_field_in_block(lines, 0, 3, "trial", "false")
-    assert any("trial: false" in line for line in result)
-
-
-def test_set_field_in_block_adds_new() -> None:
-    """Set field should add new field when not present."""
-    from digest.source_scorer import _set_field_in_block
-
-    lines = [
-        "  - name: Feed1",
-        "    url: https://example.com",
-    ]
-    result = _set_field_in_block(lines, 0, 2, "trial", "true")
-    assert any("trial: true" in line for line in result)
-
-
-def test_remove_field_in_block() -> None:
-    """Remove field should delete field line."""
-    from digest.source_scorer import _remove_field_in_block
-
-    lines = [
-        "  - name: Feed1",
-        "    trial_started: 2026-03-01",
-        "    url: https://example.com",
-    ]
-    result, new_end = _remove_field_in_block(lines, 0, 3, "trial_started")
-    assert new_end == 2
-    assert not any("trial_started" in line for line in result)
-
-
-def test_remove_field_in_block_nonexistent() -> None:
-    """Remove field should not crash if field not present."""
-    from digest.source_scorer import _remove_field_in_block
-
-    lines = [
-        "  - name: Feed1",
-        "    url: https://example.com",
-    ]
-    result, new_end = _remove_field_in_block(lines, 0, 2, "nonexistent")
-    assert new_end == 2  # No change
-    assert len(result) == 2  # No lines removed
-
-
-# --- apply_trial_decisions ---
-
-
-def test_apply_trial_decisions_promote(tmp_path: Path) -> None:
-    """Promoted source should have trial set to false."""
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "GoodFeed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True, "trial_started": "2026-03-01"},
-            {"name": "OtherFeed", "url": "https://y.com", "category": "Tech",
-             "enabled": True, "trial": False},
-        ],
+def test_load_source_state_non_dict_entry_skipped(tmp_path: Path) -> None:
+    """A non-dict source entry (e.g. bare string) is skipped; valid entries still load."""
+    import json
+    data = {
+        "schema_version": 1,
+        "sources": {
+            "GoodFeed": {"trial_started": "2026-03-01", "graduated": False, "demoted": False},
+            "BadFeed": "not-a-dict",
+        },
     }
-    config_path = tmp_path / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
-
-    apply_trial_decisions(str(config_path), promote=["GoodFeed"], demote=[])
-
-    with config_path.open("r") as f:
-        result = yaml.safe_load(f)
-
-    good = next(s for s in result["sources"] if s["name"] == "GoodFeed")
-    assert good["trial"] is False
-    # Other source should be untouched
-    other = next(s for s in result["sources"] if s["name"] == "OtherFeed")
-    assert other["enabled"] is True
+    (tmp_path / "source_state.json").write_text(json.dumps(data), encoding="utf-8")
+    store = load_source_state(str(tmp_path))
+    assert store.get_trial_started("GoodFeed") == "2026-03-01"
+    assert "BadFeed" not in store.sources
 
 
-def test_apply_trial_decisions_demote(tmp_path: Path) -> None:
-    """Demoted source should have enabled set to false."""
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "BadFeed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True, "trial_started": "2026-03-01"},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
+def test_source_state_store_roundtrip(tmp_path: Path) -> None:
+    """save/load round-trip preserves all fields."""
+    store = SourceStateStore()
+    store.set_trial_started("Feed1", "2026-03-01")
+    store.mark_graduated("Feed2")
+    store.mark_demoted("Feed3")
+    save_source_state(store, str(tmp_path))
 
-    apply_trial_decisions(str(config_path), promote=[], demote=["BadFeed"])
-
-    with config_path.open("r") as f:
-        result = yaml.safe_load(f)
-
-    bad = next(s for s in result["sources"] if s["name"] == "BadFeed")
-    assert bad["enabled"] is False
+    loaded = load_source_state(str(tmp_path))
+    assert loaded.get_trial_started("Feed1") == "2026-03-01"
+    assert loaded.is_graduated("Feed2")
+    assert loaded.is_demoted("Feed3")
+    assert not loaded.is_graduated("Feed1")
+    assert not loaded.is_demoted("Feed1")
 
 
-def test_apply_trial_decisions_noop(tmp_path: Path) -> None:
-    """Empty promote/demote lists should not modify the file."""
-    config_data = {
-        "sources": [
-            {"name": "Feed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
+def test_apply_trial_decisions_to_cache_promote() -> None:
+    """Promoted source gets graduated=True, trial_started cleared."""
+    store = SourceStateStore()
+    store.set_trial_started("Good", "2026-03-01")
+    result = apply_trial_decisions_to_cache(store, promote=["Good"], demote=[], today="2026-03-18")
+    assert result.is_graduated("Good")
+    assert result.get_trial_started("Good") is None
+    assert not result.is_demoted("Good")
 
-    original = config_path.read_text()
-    apply_trial_decisions(str(config_path), promote=[], demote=[])
-    assert config_path.read_text() == original
+
+def test_apply_trial_decisions_to_cache_demote() -> None:
+    """Demoted source gets demoted=True."""
+    store = SourceStateStore()
+    store.set_trial_started("Bad", "2026-03-01")
+    result = apply_trial_decisions_to_cache(store, promote=[], demote=["Bad"], today="2026-03-18")
+    assert result.is_demoted("Bad")
+    assert not result.is_graduated("Bad")
+
+
+def test_apply_trial_decisions_to_cache_needs_start() -> None:
+    """needs_start sources get trial_started set to today."""
+    store = SourceStateStore()
+    result = apply_trial_decisions_to_cache(store, promote=[], demote=[], today="2026-04-26", needs_start=["NewFeed"])
+    assert result.get_trial_started("NewFeed") == "2026-04-26"
 
 
 def test_evaluate_trial_needs_start_for_none_trial_started() -> None:
-    """Trial source with trial_started=None should appear in needs_start."""
-    sources = [
-        SourceConfig(
-            name="NewTrial", url="https://x.com", category="Tech",
-            enabled=True, priority=3, trial=True, trial_started=None,
-        )
-    ]
-    promote, demote, needs_start = evaluate_trial_sources(sources, {}, "2026-03-18")
+    """Trial source with no trial_started in cache should appear in needs_start."""
+    sources = [_make_trial_source("NewTrial")]
+    store = SourceStateStore()  # empty — no trial_started
+    promote, demote, needs_start = evaluate_trial_sources(sources, {}, "2026-03-18", store)
     assert promote == []
     assert demote == []
     assert "NewTrial" in needs_start
 
 
-def test_apply_trial_decisions_initializes_trial_started(tmp_path: Path) -> None:
-    """needs_start sources should get trial_started set in config."""
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "NewTrial", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
-
-    apply_trial_decisions(str(config_path), promote=[], demote=[], needs_start=["NewTrial"])
-
-    with config_path.open("r") as f:
-        result = yaml.safe_load(f)
-
-    source = result["sources"][0]
-    assert source["trial_started"] is not None
+def test_evaluate_trial_skips_graduated() -> None:
+    """Graduated source (config trial=True, cache graduated=True) is not re-evaluated."""
+    sources = [_make_trial_source("GraduatedFeed")]
+    store = SourceStateStore()
+    store.set_trial_started("GraduatedFeed", "2026-01-01")
+    store.mark_graduated("GraduatedFeed")
+    promote, demote, needs_start = evaluate_trial_sources(sources, {}, "2026-03-18", store)
+    assert "GraduatedFeed" not in promote
+    assert "GraduatedFeed" not in demote
+    assert "GraduatedFeed" not in needs_start
 
 
-def test_apply_trial_decisions_clears_trial_started_on_promote(tmp_path: Path) -> None:
-    """Promoted source should have trial_started removed."""
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "GoodFeed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True, "trial_started": "2026-03-01"},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
+def test_evaluate_trial_skips_demoted() -> None:
+    """Already-demoted source is not re-evaluated."""
+    sources = [_make_trial_source("DemotedFeed")]
+    store = SourceStateStore()
+    store.mark_demoted("DemotedFeed")
+    promote, demote, needs_start = evaluate_trial_sources(sources, {}, "2026-03-18", store)
+    assert "DemotedFeed" not in promote
+    assert "DemotedFeed" not in demote
+    assert "DemotedFeed" not in needs_start
 
-    apply_trial_decisions(str(config_path), promote=["GoodFeed"], demote=[])
-
-    with config_path.open("r") as f:
-        result = yaml.safe_load(f)
-
-    source = result["sources"][0]
-    assert source["trial"] is False
-    assert "trial_started" not in source
-
-
-def test_apply_trial_decisions_creates_and_removes_backup(tmp_path: Path) -> None:
-    """apply_trial_decisions creates a .yaml.bak before writing and removes it on success."""
-    import yaml
-
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "Feed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True, "trial_started": "2026-03-01"},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    bak_path = tmp_path / "config.yaml.bak"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
-
-    apply_trial_decisions(str(config_path), promote=["Feed"], demote=[])
-
-    # Backup must be cleaned up after a successful write
-    assert not bak_path.exists(), "Backup file should be removed after successful write"
-    # Config should still be valid
-    assert config_path.exists()
-
-
-def test_apply_trial_decisions_preserves_backup_on_write_failure(tmp_path: Path) -> None:
-    """apply_trial_decisions preserves .yaml.bak when the tmp write fails."""
-    from unittest.mock import patch
-
-    import yaml
-
-    config_data = {
-        "llm": {"provider": "anthropic", "model": "test"},
-        "delivery": {"telegram": False, "markdown_to_repo": False},
-        "digest": {"language": "ru"},
-        "sources": [
-            {"name": "Feed", "url": "https://x.com", "category": "Tech",
-             "enabled": True, "trial": True, "trial_started": "2026-03-01"},
-        ],
-    }
-    config_path = tmp_path / "config.yaml"
-    bak_path = tmp_path / "config.yaml.bak"
-    with config_path.open("w") as f:
-        yaml.dump(config_data, f)
-
-    # Patch Path.open to raise on the .yaml.tmp file only
-    real_open = open
-
-    def fail_on_tmp(self: "Path", mode: str = "r", **kwargs: object) -> object:
-        if str(self).endswith(".yaml.tmp"):
-            raise OSError("Disk full")
-        return real_open(str(self), mode, **kwargs)
-
-    import pytest as _pytest
-
-    with patch("pathlib.Path.open", fail_on_tmp):
-        with _pytest.raises(OSError, match="Disk full"):
-            apply_trial_decisions(str(config_path), promote=["Feed"], demote=[])
-
-    # Backup must survive the failed write for manual recovery
-    assert bak_path.exists(), "Backup file should remain when write fails"
 
 
 def test_update_stats_deduplicates_same_day() -> None:

--- a/tests/test_source_state_roundtrip.py
+++ b/tests/test_source_state_roundtrip.py
@@ -1,0 +1,67 @@
+"""Round-trip property test for SourceStateStore (acceptance criterion for issue #37)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from digest.source_scorer import SourceStateStore, load_source_state, save_source_state
+
+
+def test_roundtrip_trial_started(tmp_path: Path) -> None:
+    """load + mutate trial_started + save + reload → same value."""
+    store = load_source_state(str(tmp_path))
+    store.set_trial_started("MyFeed", "2026-04-26")
+    save_source_state(store, str(tmp_path))
+
+    reloaded = load_source_state(str(tmp_path))
+    assert reloaded.get_trial_started("MyFeed") == "2026-04-26"
+
+
+def test_roundtrip_graduated(tmp_path: Path) -> None:
+    """mark_graduated survives save/load cycle."""
+    store = load_source_state(str(tmp_path))
+    store.set_trial_started("GradFeed", "2026-01-01")
+    store.mark_graduated("GradFeed")
+    save_source_state(store, str(tmp_path))
+
+    reloaded = load_source_state(str(tmp_path))
+    assert reloaded.is_graduated("GradFeed")
+    assert reloaded.get_trial_started("GradFeed") is None
+
+
+def test_roundtrip_demoted(tmp_path: Path) -> None:
+    """mark_demoted survives save/load cycle."""
+    store = load_source_state(str(tmp_path))
+    store.mark_demoted("BadFeed")
+    save_source_state(store, str(tmp_path))
+
+    reloaded = load_source_state(str(tmp_path))
+    assert reloaded.is_demoted("BadFeed")
+
+
+def test_roundtrip_multiple_sources(tmp_path: Path) -> None:
+    """Multiple sources with different states all survive round-trip."""
+    store = SourceStateStore()
+    store.set_trial_started("A", "2026-03-01")
+    store.mark_graduated("B")
+    store.mark_demoted("C")
+    save_source_state(store, str(tmp_path))
+
+    reloaded = load_source_state(str(tmp_path))
+    assert reloaded.get_trial_started("A") == "2026-03-01"
+    assert reloaded.is_graduated("B")
+    assert reloaded.is_demoted("C")
+    assert not reloaded.is_demoted("A")
+    assert not reloaded.is_graduated("A")
+
+
+def test_roundtrip_empty_store(tmp_path: Path) -> None:
+    """Empty store round-trips correctly."""
+    store = SourceStateStore()
+    save_source_state(store, str(tmp_path))
+
+    reloaded = load_source_state(str(tmp_path))
+    assert reloaded.sources == {}
+    assert not reloaded.is_demoted("anything")
+    assert not reloaded.is_graduated("anything")
+    assert reloaded.get_trial_started("anything") is None


### PR DESCRIPTION
## Summary

- **Eliminates `apply_trial_decisions()` regex mutation of `config.yaml` at runtime** — the root cause of the dual-storage split identified in issue #37 and ADR-0003.
- `config.yaml` is now read-only (human-edited declarations only). All runtime trial state — `trial_started`, `graduated`, `demoted` — lives in `.cache/source_state.json` via the new `SourceStateStore`.
- Graduated sources no longer cycle back into trial on subsequent runs (new `is_graduated()` guard in `evaluate_trial_sources`).
- Demoted sources are excluded from `collect()` and from adaptive priority calculation via `Config.effective_sources(source_state)`.

## Changes

- `digest/source_scorer.py`: delete 4 YAML-helper functions; add `SourceStateEntry`, `SourceStateStore`, `load_source_state`, `save_source_state`, `apply_trial_decisions_to_cache`
- `digest/config.py`: remove `SourceConfig.trial_started`; add `Config.effective_sources(source_state)`
- `digest/main.py`: wire state load/save; replace `apply_trial_decisions` call; filter `run_config` to enabled+not-demoted sources
- `tests/test_source_state_roundtrip.py`: new round-trip property tests (acceptance criterion #37)
- `tests/test_source_scorer.py`, `tests/test_config.py`, `tests/test_main.py`: updated

## Migration impact

Existing sources with `trial_started:` in `digest-prod/config.yaml` will have their trial clock reset on first run (YAML loader silently ignores the unknown field; state initialises fresh in `.cache/source_state.json`). This is a one-time event and documented in plan.md risks.

## Known limitation (out of scope)

The discovery flow (`add_source_to_config` in `discovery.py`) still writes to `config.yaml` when a user approves a new source. Tracked separately.

## Two-voice review

- `/review` (Claude): 2 SUGGESTs fixed (stale mock field, blank lines), no BLOCKs
- `/codex-review` (Codex/gpt-5.2): 3 BLOCKs — 2 fixed (`AttributeError` in loader, `run_config` inconsistent filtering), 1 disagreed (feeds_count/save_stats semantics are intentional)

## Test plan

- [ ] `pytest tests/ --ignore=tests/test_discovery.py` — 368 passed
- [ ] `ruff check digest/ tests/` — clean
- [ ] `mypy --strict digest/` — clean
- [ ] Coverage: 76% total, `source_scorer.py` 94%

Implements docs/decisions/0003-source-state-split.md
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)