### PR TITLE
fix: replace hardcoded timestamp in pending round-trip test

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -77,7 +77,7 @@ def test_save_and_load_pending_round_trip(tmp_path: Path) -> None:
         name="The New Stack",
         url="https://thenewstack.io/feed/",
         category="Cloud & Infrastructure",
-        discovered_at="2026-03-27T10:00:00+00:00",
+        discovered_at=datetime.now(tz=timezone.utc).isoformat(),
     )
     save_pending([ps], str(tmp_path))
     loaded = load_pending(str(tmp_path))


### PR DESCRIPTION
## Summary

`test_save_and_load_pending_round_trip` used a hardcoded `discovered_at="2026-03-27T10:00:00+00:00"`. On 2026-04-26 this entry falls exactly at the 30-day prune boundary — the test passes before 10:00 UTC, fails after.

Replace with `datetime.now(tz=timezone.utc).isoformat()` so the entry is always within the window.

## QA

**Tests:** 380/380 pass (was 379/380 with the flaky failure).

**Docs:** all contracts current.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)