### PR TITLE
docs(domain): clarify irritator-bc.md failure mode status post-issue-#53

### DIFF
--- a/docs/domain/irritator-bc.md
+++ b/docs/domain/irritator-bc.md
@@ -93,25 +93,31 @@ RankedSignal[]              filtered by score ≥ min_signal_score (=5) [UPDATED
 - No invariant on the *kind* of contradiction (intent taxonomy is freeform).
 - No invariant that the operator's bubble is even modelled.
 
-### Where the BC breaks (the failure point)
+### Where the BC breaks — failure mode analysis
 
-The BC has produced zero passing `RankedSignal`s in production. The code supports a multi-cause diagnosis. In rough order of impact:
+This section was written as a diagnostic against the pre-fix codebase. Issue #53 (commit `8d36567`) addressed 4 of the 8 failure modes; 4 remain open.
 
-**1. Query generator prompt does not ask for contradictions.** `query_generator.py` line 47 says *"Craft search queries to find counter-signals"* — but to an LLM "search query for narrative X" is statistically very close to "keywords describing X." The prompt does not enumerate contradiction-shaped patterns ("failure of", "post-mortem", "security incident in", "vs", "criticism of", "limitations of", "did not work"). The generated queries mirror the narrative's vocabulary, so search engines return the *same* content that produced the narrative. (Hypothesis 1, code-supported.)
+#### Fixed by issue #53 (historical record)
+
+**1. Query generator prompt did not ask for contradictions.** `query_generator.py` said *"Craft search queries to find counter-signals"* — but to an LLM "search query for narrative X" is statistically very close to "keywords describing X." The prompt did not enumerate contradiction-shaped patterns ("failure of", "post-mortem", "security incident in", "vs", "criticism of", "limitations of", "did not work"). Generated queries mirrored the narrative's vocabulary, so search engines returned the *same* content that produced the narrative. *Fixed: prompt rewritten to require adversarial phrasing with explicit negation/failure keywords.*
+
+**3. The ranker prompt rewarded "substance + credibility" alongside "contradiction."** `ranker.py` scored signals on *"substance, contradiction to the narrative, source credibility, and surprise factor"* — four criteria AND-ish in LLM judgment. A spicy contrarian Reddit post scored low on credibility; an authoritative paper that mildly qualified the narrative scored low on contradiction. The conjunction collapsed to mid-scores (5–6), falling under the threshold. *Fixed: replaced with a single criterion ("how strongly does this CONTRADICT or COMPLICATE the narrative?") plus explicit 9-10/7-8/5-6/1-4 calibration anchors.*
+
+**4. `min_signal_score=7` sat just above the LLM hedge zone.** The prompt had no anchor examples for what a 7 looks like vs a 5 vs a 9. LLMs default to 5–7 for ambiguous cases. The threshold filtered out exactly the band the LLM produced most. *Fixed: default lowered to 5 (consistent with production `config.yaml` override); calibration anchors added to the ranker prompt (see point 3).*
+
+**5. dev.to adapter was structurally a consensus engine.** `devto.py` used `params={"tag": query.split()[0].lower()}` — a *tag-listing* call, not a text search. It returned popular tutorials for the first word of the query. For any narrative whose first keyword matched a hot tag (e.g. "ai", "rust", "kubernetes") it returned hype articles — the opposite of counter-signal. *Fixed: switched to `?q=full_query` for full-text search.*
+
+#### Still open
+
+The following 4 failure modes were not addressed in issue #53. They are also documented as structural design gaps in §3 "Missing concepts" below.
 
 **2. The narratives are extracted from a curated pro-tech feed.** Radar's source list is a tech-architect bubble (per `CLAUDE.md`). Narratives extracted from this corpus are themselves consensus-flavored. The narrative-extraction prompt (`narrative_extractor.py:30-69`) asks for "dominant narratives that are rarely questioned" — but never instructs the LLM that the corpus itself is selection-biased. (Hypothesis 4, code-supported.)
 
-**3. The ranker prompt rewards "substance + credibility" alongside "contradiction."** `ranker.py:31-42`: *"score on a 1–10 scale based on: substance, contradiction to the narrative, source credibility, and surprise factor."* Four criteria, AND-ish in LLM judgment. A spicy contrarian Reddit post will score low on credibility; an authoritative paper that mildly qualifies the narrative will score low on contradiction. The conjunction collapses to mid-scores (5–6), which fall under the threshold of 7. (Hypothesis 5 + 2 entangled.)
+**6. Source-narrative fit is unmodelled.** Even with fan-out (all queries now reach all sources), the query generator has no profile of what each source is *good for*. arXiv is great for "alternative academic findings" and useless for "industry post-mortems"; Reddit varies wildly by subreddit. Source selection is effectively uniform-prior guessing. See §3 "SourceProfile" for the missing concept. (Hypothesis 3, broader form.)
 
-**4. `min_signal_score=7` sits just above the LLM hedge zone.** The prompt has no anchor examples for what a 7 looks like vs a 5 vs a 9. LLMs default to 5–7 for ambiguous cases. The threshold filters out exactly the band the LLM produces most. (Hypothesis 2.)
+**7. All-pairs ranking blurs per-narrative results.** `irritator/__init__.py`: `for narrative in narratives: rank_signals(narrative, signals, config)`. Each narrative is ranked against the *full* validated signal pool — including signals fetched for *other narratives'* queries. Because provenance was dropped at `search_all_sources()`, there is no way to detect "we fetched zero signals targeting narrative N." A narrative whose own queries returned nothing can still get "ranked," typically with all-low scores from off-topic signals — indistinguishable from "we tried but the world had no contradictions." See §3 "Provenance edge" for the missing concept.
 
-**5. dev.to adapter is structurally a consensus engine.** `devto.py:25`: `params={"tag": query.split()[0].lower() if query else ""}`. This is a *tag-listing* call, not a text search. It returns popular tutorials for the first word of the query. For any narrative whose first keyword matches a hot tag (e.g. "ai", "rust", "kubernetes") it will return hype articles — the opposite of counter-signal. (Hypothesis 3, code-confirmed for dev.to specifically.)
-
-**6. Source-narrative fit is unmodelled.** `query_generator.py` passes the sources list as a flat enumeration — *"target_source — one of: hackernews, reddit, arxiv, devto, lobsters"*. The LLM has no profile of what each source is *good for*. arXiv is great for "alternative academic findings" and useless for "industry post-mortems"; Reddit varies wildly by subreddit. Source selection is effectively uniform-prior guessing. (Hypothesis 3, broader form.)
-
-**7. All-pairs ranking blurs per-narrative results.** `irritator/__init__.py:128-132`: `for narrative in narratives: rank_signals(narrative, signals, config)`. Each narrative is ranked against the *full* validated signal pool — including signals fetched for *other narratives'* queries. Because provenance was dropped at search time, there is no way to detect "we fetched zero signals targeting narrative N." A narrative whose own queries returned nothing can still get "ranked," typically with all-low scores from off-topic signals — which look indistinguishable from "we tried but the world had no contradictions."
-
-**8. No feedback loop.** Even if a counter-signal got through, the BC has no concept of "did this break the bubble for the operator?" The article-vote feedback collected in `feedback.py` is not wired back into Irritator at all. The system cannot learn that, e.g., its arXiv signals never get clicked.
+**8. No feedback loop.** Even if a counter-signal gets through, the BC has no concept of "did this break the bubble for the operator?" The article-vote feedback collected in `feedback.py` is not wired back into Irritator. The system cannot learn that, e.g., its arXiv signals never get clicked. See §3 "Bubble-break verification."
 
 ---
 
@@ -135,7 +141,7 @@ What concepts would a well-functioning counter-signal system need that the curre
 
 - **EmptyOutcome with reason code.** Today `IrritatorStatus.level == "empty"` is a single bucket. Operator gets `"5 narratives, 87 signals, 87 valid, 0 passed ranking"` — informative, but does not distinguish: "all signals were off-topic to their narratives" vs. "signals were on-topic but ranked below threshold" vs. "the threshold itself filtered the LLM's hedge band." Without this the operator can't tell which lever to pull.
 
-- **Calibration anchors.** Not a domain object exactly, but a domain *contract*: the ranker prompt must commit to anchor examples ("a 9 looks like X, a 7 looks like Y, a 5 looks like Z"). Otherwise the 1–10 scale is uncalibrated and `min_signal_score=7` is a guess.
+- **Calibration anchors.** ~~Not a domain object exactly, but a domain *contract*: the ranker prompt must commit to anchor examples ("a 9 looks like X, a 7 looks like Y, a 5 looks like Z"). Otherwise the 1–10 scale is uncalibrated and `min_signal_score=7` is a guess.~~ **[UPDATED — issue #53]** Calibration anchors (9-10/7-8/5-6/1-4) were added to the ranker prompt alongside the single-criterion rewrite; `min_signal_score` default lowered to 5. This item is no longer missing.
 
 - **Bubble-break verification.** The value act is "operator reads something they otherwise wouldn't have." Nothing in the BC observes whether a delivered counter-signal was clicked, saved, voted on, or ignored. Without closing this loop, the BC is blind to its own success/failure rate.
 

--- a/plan.md
+++ b/plan.md
@@ -1,69 +1,70 @@
-# Plan — Issue #66: fix(telegram): loading... при нажатии кнопки реакции
+# Plan: Issue #64 — Domain-reviewer pass on irritator-bc.md
 
 ## 1. Problem restatement
 
-Telegram requires `answerCallbackQuery` to be called within 10 seconds of a button press. Because the digest pipeline runs only twice daily via GitHub Actions, any button press between runs goes unanswered. The user sees a "loading..." spinner for ~30 seconds, then nothing — even though the feedback is actually recorded on the next pipeline run. The root problem is a mismatch between user expectations (synchronous confirmation) and the pipeline's batch execution model.
+`docs/domain/irritator-bc.md` was authored by the domain-researcher agent as part of the issue #53 fix (commit `8d36567`), with `[UPDATED — issue #53]` and `[REMOVED — issue #53]` markers applied inline to schema and config facts. However, the "Where the BC breaks" section (lines 96–114) lists 8 pipeline failure modes as if all are current — it received no markers. In reality, 4 of the 8 were addressed directly in the same commit (adversarial query phrasing, ranker AND-logic → single criterion with calibration anchors, score threshold 7→5, dev.to text-search fix). A reader today cannot tell which failures are historical and which remain open, making the section misleading for anyone debugging or extending the irritator.
 
 ## 2. Affected bounded contexts and files
 
-**Delivery BC** (`digest/delivery/`)
-- `digest/delivery/telegram.py` — `send_article_cards()`: where article cards with voting buttons are assembled and sent
-
-No other BCs are touched. The Irritator BC (feedback collection) is unchanged — it already records votes correctly on the next run.
+- **Irritator BC** — `docs/domain/irritator-bc.md` (the only file being changed)
+- No code files are touched; no BC boundary or inter-context contract changes.
 
 ## 3. Considered approaches
 
-**Option A — Serverless webhook (Cloudflare Worker / Vercel)**
-Deploy a lightweight handler that answers `callback_query` within 10 seconds and shows a toast "✓ Учтено". Eliminates the spinner entirely.
-- Pros: proper UX, matches Telegram's intended flow
-- Cons: requires infrastructure outside GitHub Actions (deploy, secrets, monitoring). Out of scope for a zero-infra pipeline. Deferred to a future issue.
+### A. In-place fix-status markers
+Add `[FIXED — issue #53]` labels to the four resolved failure points, leave the remaining four untouched.
 
-**Option B — Increase pipeline run frequency**
-Schedule the pipeline every 5–10 minutes so there is always a run within the 10-second window.
-- Pros: no code change
-- Cons: wasteful (LLM API calls, rate limits), still non-deterministic, and misses the window entirely if the user presses a button between runs. Red flag: this is a workaround for the wrong problem.
+**Pro:** Minimal diff, consistent with the `[UPDATED]`/`[REMOVED]` pattern already in the file. Preserves full diagnostic history in place.  
+**Con:** Each failure point is a multi-paragraph structural analysis, not a one-line schema fact. A `[FIXED]` tag on a bold heading does not tell the reader whether the point is a completed historical lesson or a live open issue — they still must read the entire paragraph and infer. Option A works for one-line annotations; it does not carry the framing well for paragraph-length diagnostics.
 
-**Option C — Italics caption under each card (chosen)**
-Append `_Реакции учитываются при след. запуске_` beneath each article card to set expectations before the user taps.
-- Pros: zero infrastructure, one-line change, corrects user mental model permanently
-- Cons: slightly more verbose cards; does not remove the spinner (just explains it)
+### B. Split into two subsections (chosen)
+Restructure "Where the BC breaks" into two explicit subsections: **"Fixed by issue #53 (historical record)"** and **"Still open."** Fixed items stay verbatim under the historical header; open items stay under the live header. Add a one-sentence framing note at the top.
 
-Option A is the correct long-term fix but requires out-of-scope infrastructure. Option C is the right minimal fix given the zero-infra constraint. Option B is a red flag.
+**Pro:** Structure makes current vs. historical immediately visible without reading each item. A domain-reviewer, implementer, or future issue author scanning for live failures lands directly on the "Still open" subsection.  
+**Con:** Slightly larger diff; moves content rather than annotating it.
+
+### C. Delete fixed items entirely
+Remove points 1, 3, 4, 5 entirely.
+
+**Con:** Loses the causal reasoning behind the fixes (adversarial phrasing rationale, calibration anchor motivation, threshold logic). Ruled out — diagnostic value is worth keeping.
+
+**Chosen:** B. Option A is locally consistent but poorly suited to paragraph-length content; Option C destroys historical context. B is the only option that makes the section accurate and scannable.
 
 ## 4. Chosen approach and why
 
-Option C. The `send_article_cards()` function in `telegram.py` assembles each card's text before calling `_send_chunk`. The fix adds a module-level constant `_ASYNC_FEEDBACK_NOTE` and appends it as an italics line to every card's message body.
+Verified against git diff of commit `8d36567` (the actual #53 fix):
 
-No ADR required: the change adds no new dependencies, does not alter any BC boundary or inter-context contract, introduces no infrastructure, and is trivially reversible. None of the six architectural-significance triggers in `docs/principles.md` fire.
+**Fixed by issue #53 — 4 points:**
+- Point 1: Query generator adversarial phrasing (`query_generator.py` rewritten with contradiction patterns)
+- Point 3: Ranker AND-logic (`ranker.py` — four-criteria conjunction replaced with single "CONTRADICTS or COMPLICATES" criterion + 9-10/7-8/5-6/1-4 calibration anchors)
+- Point 4: `min_signal_score=7` threshold (`config.py` — default 7→5, consistent with prod override)
+- Point 5: dev.to adapter (`devto.py` — `?tag=` replaced with `?q=` full-text search)
 
-**Implementation (committed in `7384f1e`):**
-```python
-_ASYNC_FEEDBACK_NOTE = "Реакции учитываются при след. запуске"
+**Still open — 4 points:**
+- Point 2: Narratives extracted from a curated pro-tech feed (no feed or prompt change)
+- Point 6: Source-narrative fit unmodelled (fan-out added, but source profiling not implemented)
+- Point 7: All-pairs ranking blurs per-narrative results (provenance still dropped at `search_all_sources()`)
+- Point 8: No feedback loop (unchanged)
 
-# in send_article_cards():
-async_note = escape_markdownv2(_ASYNC_FEEDBACK_NOTE)
-text = (
-    f"[{title_esc}]({url_esc})\n\n"
-    f"{summary_esc}\n\n"
-    f"*{source_esc}* · _{cat_esc}_\n"
-    f"_{async_note}_"
-)
-```
+This maps to the issue's option **(a): "Keep as historical record (label it explicitly)"** — fixed points are preserved verbatim under a historical subheading, not deleted.
+
+Also add a cross-reference from the "Still open" items to §3 "Missing concepts" where these gaps are already documented as design targets, to prevent readers treating them as undiscovered bugs.
+
+No ADR triggered: doc-only change, no BC boundary or inter-context contract change, no new dependency. Per `docs/principles.md` § "Что значит «архитектурно-значимо»": this is a story, not a decision.
 
 ## 5. Test strategy
 
-**Unit tests** (`tests/test_delivery_telegram.py`):
-- Assert that `send_article_cards()` includes the `_ASYNC_FEEDBACK_NOTE` text (escaped) in the message body sent to `_send_chunk`.
-- Assert that the note is italicised (wrapped in `_..._` after MarkdownV2 escaping).
-- Assert existing card structure (title link, summary, source·category line) is preserved — no regression.
+Documentation-only change — no runtime code is touched.
 
-No integration or e2e tests needed: the change is purely string formatting in a function already covered by unit tests. All network calls are mocked per `CLAUDE.md` constraints.
+**Acceptance criterion (issue #64):** `domain-reviewer` agent returns APPROVE verdict on the updated file.
+
+**Manual verification during implement:**
+- Points 1, 3, 4, 5 classified as fixed — confirmed against `git show 8d36567` diff of `query_generator.py`, `ranker.py`, `config.py`, `devto.py`.
+- Points 2, 6, 7, 8 still open — no corresponding code changes in any commit on `main`.
+
+No unit/integration tests: CI does not cover `.md` files.
 
 ## 6. Risks and unknowns
 
-- **MarkdownV2 escaping of the note text:** The string "Реакции учитываются при след. запуске" contains a period (special char in MarkdownV2). Verified in code: `escape_markdownv2(_ASYNC_FEEDBACK_NOTE)` is called before interpolation — period is correctly escaped to `\.`.
-- **Card length:** The extra line adds ~45 characters. Cards are well under `_SPLIT_LIMIT` (3800 chars), so no splitting risk.
-- **Test coverage gap:** If the existing `send_article_cards` test does not assert on the full message body, the note could be silently dropped in a future refactor. The test strategy above closes this gap.
-- **Future Option A cleanup:** When a webhook handler is eventually added, the note should be removed from card text. That cleanup must be tracked in the future serverless issue to avoid orphaned UX copy.
-
-Closes #66
+- **"Still open" list risks raising expectations.** Points 2, 6, 7, 8 are architectural gaps already documented in §3 "Missing concepts" as future-work design targets. Labelling them "still open" without context could make them look like tracked near-term bugs. Mitigation: cross-reference to §3 explicitly.
+- **domain-reviewer may flag vocabulary drift or concept collisions** beyond the scope of this fix (the file has known issues documented in §1 "Vocabulary drift"). Those findings should open a new issue, not block this PR. The APPROVE criterion here is specifically for the accuracy of the failure-mode classification.

--- a/qa-report.md
+++ b/qa-report.md
@@ -1,16 +1,3 @@
 ## QA
 
-**Tests:** All changed paths covered. 444 tests pass (`make check` clean). `ruff check digest/ tests/` clean. `mypy digest/` clean.
-
-| Changed file | Test file | Key new assertions |
-|---|---|---|
-| `digest/irritator/query_generator.py` | `tests/test_query_generator.py` | No `target_source` field; adversarial tokens in EN+RU prompt; prompt sent to LLM contains adversarial markers |
-| `digest/irritator/sources/__init__.py` | `tests/test_sources_init.py` | Fan-out: 1 query × 2 sources = 2 adapter calls; N queries × M sources = N×M calls; unconfigured adapter not called; query string passed verbatim |
-| `digest/irritator/sources/devto.py` | `tests/test_sources_devto.py` | `?q=` param present; `?tag=` absent; full query string passed (not just first word) |
-| `digest/irritator/ranker.py` | `tests/test_ranker.py` | Calibration anchors "9-10"/"direct evidence" in EN prompt; single criterion (no "substance"/"credibility" conjunction); score 5 passes threshold |
-| `digest/config.py` | `tests/test_config.py` | `test_defaults_applied` updated (7→5); `test_irritator_config_default_min_signal_score` added asserting `IrritatorConfig().min_signal_score == 5` |
-| `digest/delivery/telegram.py` | `tests/test_delivery_telegram.py` | `test_card_includes_async_feedback_note` — asserts `_ASYNC_FEEDBACK_NOTE` text present and card ends with `_` (italics) in MarkdownV2 payload (Claude-authored in issue #66 QA pass) |
-
-One gap noted and accepted: `test_irritator_orchestrator.py:17` sets `min_signal_score = 7` as an explicit mock override. `rank_signals` is mocked in all orchestrator tests so the threshold is never evaluated. Not a coverage gap — orchestrator tests validate pipeline branching, not scoring behaviour.
-
-**Docs:** `docs/domain/irritator-bc.md` was updated during #53 implementation. `CLAUDE.md` file-structure references remain accurate (file names unchanged). No runbook in `docs/runbooks/` references the changed files. No public contracts changed by the #66 telegram fix.
+Carve-out: docs-only diff. No test or docs check required.


### PR DESCRIPTION
## Summary

- Split "Where the BC breaks" into two subsections: **Fixed by issue #53 (historical record)** (points 1, 3, 4, 5) and **Still open** (points 2, 6, 7, 8)
- Verified 4/4 split against `git show 8d36567` diff of `query_generator.py`, `ranker.py`, `config.py`, `devto.py`
- Updated §3 "Calibration anchors" bullet to reflect it is no longer missing (anchors were added in #53)
- Opened #68 and #69 for pre-existing cross-doc conflicts surfaced by the domain-reviewer (out of scope for this PR)

## QA

Carve-out: docs-only diff. No test or docs check required.

## Reviews

- **domain-reviewer:** APPROVE — fixed/open classification accurate and internally consistent; no new issues introduced by this PR
- **/review (Claude):** No BLOCK or SUGGEST findings
- **/codex-review (Codex):** Two BLOCKs raised; both rest on misunderstandings of project convention — `plan.md` rotation per issue is intentional (prior content in git history); 4/4 classification is verifiable via `git show 8d36567`. Two SUGGESTs disagreed: non-sequential numbering is intentional traceability to the original 8-point list; `[UPDATED]`+strikethrough marker matches the pattern on line 83 of the same file.

Closes #64