### PR TITLE
fix(delivery): /bubble shows topic categories instead of raw source names

### DIFF
--- a/digest/feedback.py
+++ b/digest/feedback.py
@@ -210,12 +210,16 @@ async def collect_feedback(
                             if chat_id:
                                 from digest.source_scorer import (
                                     compute_bubble_report,
+                                    load_source_category_map,
                                     load_source_state,
                                     load_stats,
                                 )
                                 stats = load_stats(cache_dir)
                                 state = load_source_state(cache_dir)
-                                report = compute_bubble_report(store, stats, state)
+                                category_map = load_source_category_map(cache_dir)
+                                report = compute_bubble_report(
+                                    store, stats, state, category_map=category_map or None
+                                )
                                 try:
                                     send_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
                                     await client.post(

--- a/digest/main.py
+++ b/digest/main.py
@@ -445,6 +445,7 @@ async def run(
         evaluate_trial_sources,
         load_source_state,
         load_stats,
+        save_source_category_map,
         save_source_state,
         save_stats,
     )
@@ -635,6 +636,7 @@ async def run(
     save_feedback(feedback_store, cache_dir)
     save_source_state(source_state, cache_dir)
     save_stats(source_stats, cache_dir, active_sources={s.name for s in config.enabled_sources})
+    save_source_category_map(config.enabled_sources, cache_dir)
 
     return RunStats(
         feeds_fetched=feeds_count, new_articles=total_articles,

--- a/digest/source_scorer.py
+++ b/digest/source_scorer.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 STATS_FILE = "source_stats.json"
 SOURCE_STATE_FILE = "source_state.json"
+CATEGORY_MAP_FILE = "source_category_map.json"
 SOURCE_STATE_SCHEMA_VERSION = 1
 HISTORY_MAX_DAYS = 30
 
@@ -135,6 +136,32 @@ def save_source_state(store: SourceStateStore, cache_dir: str) -> None:
         atomic_json_write(path, data)
     except Exception as exc:
         logger.warning("Failed to save source_state.json: %s", exc)
+
+
+def save_source_category_map(sources: list[SourceConfig], cache_dir: str) -> None:
+    """Persist {source_name: category} mapping for /bubble analytics."""
+    path = Path(cache_dir) / CATEGORY_MAP_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {s.name: s.category for s in sources}
+    try:
+        atomic_json_write(path, data)
+    except Exception as exc:
+        logger.warning("Failed to save source_category_map.json: %s", exc)
+
+
+def load_source_category_map(cache_dir: str) -> dict[str, str]:
+    """Load {source_name: category} from cache. Returns empty dict if missing."""
+    path = Path(cache_dir) / CATEGORY_MAP_FILE
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except Exception as exc:
+        logger.warning("Failed to load source_category_map.json: %s", exc)
+    return {}
 
 
 def load_stats(cache_dir: str) -> dict[str, SourceStats]:
@@ -479,6 +506,7 @@ def compute_bubble_report(
     feedback_store: FeedbackStore,
     source_stats: dict[str, SourceStats],
     source_state: SourceStateStore,
+    category_map: dict[str, str] | None = None,
 ) -> str:
     """Build a single-screen filter bubble snapshot from cached data. No I/O."""
     now = datetime.now(tz=timezone.utc)
@@ -502,15 +530,27 @@ def compute_bubble_report(
     lines.append(f"Diversity: {label} ({score:.0f}/100)")
     lines.append("")
 
-    recent_sources: dict[str, int] = {
-        name: sum(snap.articles_included for snap in s.history[-7:])
-        for name, s in source_stats.items()
-        if sum(snap.articles_included for snap in s.history[-7:]) > 0
-    }
+    recent_sources: dict[str, int] = {}
+    for name, s in source_stats.items():
+        count = sum(snap.articles_included for snap in s.history[-7:])
+        if count > 0:
+            recent_sources[name] = count
+
     if recent_sources:
-        lines.append("Top sources (7d):")
-        for name, count in sorted(recent_sources.items(), key=lambda x: x[1], reverse=True)[:5]:
-            lines.append(f"  {name}: {count} art")
+        total_recent = sum(recent_sources.values())
+        if category_map:
+            category_counts: dict[str, int] = {}
+            for src, count in recent_sources.items():
+                cat = category_map.get(src, "Other")
+                category_counts[cat] = category_counts.get(cat, 0) + count
+            lines.append("Your bubble (7d):")
+            for cat, count in sorted(category_counts.items(), key=lambda x: x[1], reverse=True):
+                pct = round(count / total_recent * 100)
+                lines.append(f"  {cat}: {count} art ({pct}%)")
+        else:
+            lines.append("Top sources (7d):")
+            for name, count in sorted(recent_sources.items(), key=lambda x: x[1], reverse=True)[:5]:
+                lines.append(f"  {name}: {count} art")
         lines.append("")
 
     cutoff = now - timedelta(days=14)

--- a/tests/test_bubble_analytics.py
+++ b/tests/test_bubble_analytics.py
@@ -17,6 +17,8 @@ from digest.source_scorer import (
     SourceStats,
     _diversity_score,
     compute_bubble_report,
+    load_source_category_map,
+    save_source_category_map,
 )
 
 # ---------------------------------------------------------------------------
@@ -199,6 +201,61 @@ def test_compute_bubble_report_top_sources_capped_at_5() -> None:
     stats = {f"S{i}": _make_stats(f"S{i}", [i + 1] * 7) for i in range(10)}
     report = compute_bubble_report(FeedbackStore(), stats, SourceStateStore())
     assert report.count("  S") <= 5
+
+
+def test_compute_bubble_report_with_category_map_shows_topics() -> None:
+    """When category_map provided, report shows 'Your bubble' by topic, not source names."""
+    stats = {
+        "TechFeed": _make_stats("TechFeed", [10] * 7),
+        "FinFeed": _make_stats("FinFeed", [5] * 7),
+        "SecFeed": _make_stats("SecFeed", [5] * 7),
+    }
+    category_map = {"TechFeed": "AI & LLM", "FinFeed": "FinTech", "SecFeed": "FinTech"}
+    report = compute_bubble_report(FeedbackStore(), stats, SourceStateStore(), category_map=category_map)
+    assert "Your bubble" in report
+    assert "AI & LLM" in report
+    assert "FinTech" in report
+    assert "Top sources" not in report
+
+
+def test_compute_bubble_report_category_percentages_sum_to_100() -> None:
+    stats = {
+        "A": _make_stats("A", [3] * 7),
+        "B": _make_stats("B", [1] * 7),
+    }
+    category_map = {"A": "Tech", "B": "Finance"}
+    report = compute_bubble_report(FeedbackStore(), stats, SourceStateStore(), category_map=category_map)
+    assert "75%" in report  # A: 3/(3+1) = 75%
+    assert "25%" in report  # B: 1/(3+1) = 25%
+
+
+def test_compute_bubble_report_empty_category_map_falls_back_to_sources() -> None:
+    """Empty category_map (no data yet) falls back to top-sources display."""
+    stats = {"Feed": _make_stats("Feed", [5] * 7)}
+    report = compute_bubble_report(FeedbackStore(), stats, SourceStateStore(), category_map={})
+    assert "Top sources" in report
+    assert "Your bubble" not in report
+
+
+# ---------------------------------------------------------------------------
+# save_source_category_map / load_source_category_map
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_source_category_map_round_trip(tmp_path: Path) -> None:
+    from digest.config import SourceConfig
+    sources = [
+        SourceConfig(name="HN", url="https://hn.com", category="Tech", enabled=True),
+        SourceConfig(name="PYMNTS", url="https://pymnts.com", category="FinTech", enabled=True),
+    ]
+    save_source_category_map(sources, str(tmp_path))
+    loaded = load_source_category_map(str(tmp_path))
+    assert loaded == {"HN": "Tech", "PYMNTS": "FinTech"}
+
+
+def test_load_source_category_map_missing_file(tmp_path: Path) -> None:
+    result = load_source_category_map(str(tmp_path))
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces "Top sources (7d)" section in `/bubble` with "Your bubble (7d)" — category distribution with percentages
- Saves `{source_name: category}` to `.cache/source_category_map.json` on each pipeline run via `save_source_category_map()`
- `/bubble` handler loads the map and groups article counts by category
- Falls back to source-name list when map not yet present (first run after upgrade)
- 5 new tests; full suite: 454 passed

## Example output

```
=== Filter Bubble Report ===
Generated: 2026-04-28 11:00 UTC

Last digest: 2026-04-28 05:27 UTC (6h ago)
Diversity: Diverse (81/100)

Your bubble (7d):
  FinTech & Banking: 35 art (35%)
  AI & LLM: 28 art (28%)
  Architecture: 22 art (22%)
  Security: 10 art (10%)

Feedback (14d): 0 votes — +0 / -0
Sources: 0 graduated | 1 trial | 0 demoted
```

## QA

**Tests:** 22 tests in `test_bubble_analytics.py`. 454 total passed. Ruff clean, mypy clean.

**Note:** Category map populates on the first pipeline run after merge. Before that, `/bubble` shows the source-name fallback.

Closes #49