### PR TITLE
feat: terse article summaries + /bubble analytics (#55, #71, #72)

### DIFF
--- a/digest/feedback.py
+++ b/digest/feedback.py
@@ -16,6 +16,7 @@ from digest._util import atomic_json_write
 logger = logging.getLogger(__name__)
 
 FEEDBACK_FILE = "feedback.json"
+TELEGRAM_TEXT_LIMIT = 4096
 
 
 @dataclass
@@ -115,6 +116,59 @@ def save_feedback(store: FeedbackStore, cache_dir: str) -> None:
         logger.warning("Failed to save feedback: %s", exc)
 
 
+async def _handle_bot_command(
+    text: str,
+    chat_id: str,
+    owner_chat_id: str,
+    bot_token: str,
+    store: "FeedbackStore",
+    cache_dir: str,
+    client: httpx.AsyncClient,
+) -> None:
+    """Dispatch /status and /bubble commands; silently drop unknown chat_ids."""
+    if not chat_id or chat_id != owner_chat_id:
+        return
+    send_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    if text == "/status":
+        reply = (
+            f"Last digest: {store.last_digest_time or 'unknown'}\n"
+            f"Sources: {len(store.last_digest_sources)}"
+        )
+        try:
+            await client.post(send_url, json={"chat_id": chat_id, "text": reply})
+        except Exception as exc:
+            logger.warning(
+                "Failed to send /status reply (chat_id=%s): %s",
+                chat_id,
+                exc.__class__.__name__,
+            )
+    elif text == "/bubble":
+        from digest.source_scorer import (
+            compute_bubble_report,
+            load_source_category_map,
+            load_source_state,
+            load_stats,
+        )
+        report = compute_bubble_report(
+            store,
+            load_stats(cache_dir),
+            load_source_state(cache_dir),
+            category_map=load_source_category_map(cache_dir) or None,
+        )
+        try:
+            await client.post(
+                send_url,
+                json={"chat_id": chat_id, "text": report[:TELEGRAM_TEXT_LIMIT]},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to send /bubble reply (chat_id=%s, len=%d): %s",
+                chat_id,
+                len(report),
+                exc.__class__.__name__,
+            )
+
+
 async def collect_feedback(
     bot_token: str, store: FeedbackStore, *, cache_dir: str = ".cache"
 ) -> FeedbackStore:
@@ -125,7 +179,11 @@ async def collect_feedback(
     """
     offset = store.last_update_id + 1 if store.last_update_id > 0 else None
     api_url = f"https://api.telegram.org/bot{bot_token}/getUpdates"
-    owner_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+    owner_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "").strip()
+    if not owner_chat_id:
+        logger.warning(
+            "TELEGRAM_CHAT_ID is not set — /status and /bubble commands will be silently ignored"
+        )
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -190,50 +248,12 @@ async def collect_feedback(
                     message = update.get("message")
                     if message:
                         text = message.get("text", "").strip()
-                        if text == "/status":
-                            chat_id = str(message.get("chat", {}).get("id", ""))
-                            if chat_id and chat_id == owner_chat_id:
-                                last_time = store.last_digest_time or "unknown"
-                                source_count = len(store.last_digest_sources)
-                                status_text = (
-                                    f"Last digest: {last_time}\n"
-                                    f"Sources: {source_count}"
-                                )
-                                try:
-                                    send_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-                                    await client.post(
-                                        send_url,
-                                        json={"chat_id": chat_id, "text": status_text},
-                                    )
-                                except Exception as exc:
-                                    logger.warning("Failed to send /status reply: %s", exc)
-                        elif text == "/bubble":
-                            chat_id = str(message.get("chat", {}).get("id", ""))
-                            if chat_id and chat_id == owner_chat_id:
-                                from digest.source_scorer import (
-                                    compute_bubble_report,
-                                    load_source_category_map,
-                                    load_source_state,
-                                    load_stats,
-                                )
-                                stats = load_stats(cache_dir)
-                                state = load_source_state(cache_dir)
-                                category_map = load_source_category_map(cache_dir)
-                                report = compute_bubble_report(
-                                    store, stats, state, category_map=category_map or None
-                                )
-                                try:
-                                    send_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-                                    await client.post(
-                                        send_url,
-                                        json={"chat_id": chat_id, "text": report[:4096]},
-                                    )
-                                except Exception:
-                                    logger.warning(
-                                        "Failed to send /bubble reply (chat_id=%s, len=%d)",
-                                        chat_id,
-                                        len(report),
-                                    )
+                        if text in ("/status", "/bubble"):
+                            chat_id = str(message.get("chat", {}).get("id") or "")
+                            await _handle_bot_command(
+                                text, chat_id, owner_chat_id,
+                                bot_token, store, cache_dir, client,
+                            )
                         continue
 
                     callback_query = update.get("callback_query")

--- a/digest/feedback.py
+++ b/digest/feedback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -124,6 +125,7 @@ async def collect_feedback(
     """
     offset = store.last_update_id + 1 if store.last_update_id > 0 else None
     api_url = f"https://api.telegram.org/bot{bot_token}/getUpdates"
+    owner_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -190,7 +192,7 @@ async def collect_feedback(
                         text = message.get("text", "").strip()
                         if text == "/status":
                             chat_id = str(message.get("chat", {}).get("id", ""))
-                            if chat_id:
+                            if chat_id and chat_id == owner_chat_id:
                                 last_time = store.last_digest_time or "unknown"
                                 source_count = len(store.last_digest_sources)
                                 status_text = (
@@ -207,7 +209,7 @@ async def collect_feedback(
                                     logger.warning("Failed to send /status reply: %s", exc)
                         elif text == "/bubble":
                             chat_id = str(message.get("chat", {}).get("id", ""))
-                            if chat_id:
+                            if chat_id and chat_id == owner_chat_id:
                                 from digest.source_scorer import (
                                     compute_bubble_report,
                                     load_source_category_map,
@@ -224,10 +226,14 @@ async def collect_feedback(
                                     send_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
                                     await client.post(
                                         send_url,
-                                        json={"chat_id": chat_id, "text": report},
+                                        json={"chat_id": chat_id, "text": report[:4096]},
                                     )
-                                except Exception as exc:
-                                    logger.warning("Failed to send /bubble reply: %s", exc)
+                                except Exception:
+                                    logger.warning(
+                                        "Failed to send /bubble reply (chat_id=%s, len=%d)",
+                                        chat_id,
+                                        len(report),
+                                    )
                         continue
 
                     callback_query = update.get("callback_query")

--- a/digest/main.py
+++ b/digest/main.py
@@ -464,6 +464,7 @@ async def run(
 
     saved_update_id = feedback_store.last_update_id
     saved_ratings_count = len(feedback_store.ratings)
+    saved_article_source_map = dict(feedback_store.article_source_map)
 
     if config.adaptive.enabled:
         if not dry_run:
@@ -629,9 +630,19 @@ async def run(
                 sources_promoted = len(promote)
                 sources_demoted = len(demote)
     else:
-        # Roll back feedback state — updates will be reprocessed on next run
+        # Roll back feedback state — updates will be reprocessed on next run.
+        # article_source_map is also rewound to prevent FIFO eviction of mappings
+        # for cards that were never delivered.
+        logger.info(
+            "Delivery failed — rolling back feedback: last_update_id %d→%d, ratings %d→%d",
+            feedback_store.last_update_id,
+            saved_update_id,
+            len(feedback_store.ratings),
+            saved_ratings_count,
+        )
         feedback_store.last_update_id = saved_update_id
         feedback_store.ratings = feedback_store.ratings[:saved_ratings_count]
+        feedback_store.article_source_map = saved_article_source_map
 
     save_feedback(feedback_store, cache_dir)
     save_source_state(source_state, cache_dir)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture — Daily News Digest v1.0.0
 
+> Bounded Context docs: [Digest BC](domain/digest/overview.md) · [Irritator BC](domain/irritator/overview.md)
+
 ## Overview
 
 Персональный генератор ежедневного новостного дайджеста. Работает полностью на GitHub Actions — без VPS, без постоянно запущенных процессов. Состояние между запусками хранится в JSON-файлах, которые коммитятся обратно в репозиторий.
@@ -18,10 +20,10 @@ sequenceDiagram
     participant col as collector.py
     participant sum as summarizer.py
     participant tg as telegram.py
-    participant md as markdown_writer.py
+    participant md as delivery/markdown.py
     participant cache as .cache/ (git)
 
-    GHA->>main: запуск python -m src
+    GHA->>main: запуск python -m digest
     main->>cache: load_config(), load_stats(), load_feedback()
     main->>fb: collect_feedback() — getUpdates polling
     fb-->>cache: обновить feedback.json (ratings, last_update_id)
@@ -58,7 +60,7 @@ sequenceDiagram
 | `feedback.py` | Polling Telegram getUpdates. Парсинг callback-запросов (`fb:a:g:{hash}`, `fb:a:b:{hash}`). Хранение оценок в `feedback.json`. |
 | `source_scorer.py` | Вычисление quality score по 4 метрикам. `calculate_effective_priorities()`. Обнаружение trending-источников. Trial source evaluation. |
 | `discovery.py` | LLM-генерация кандидатов источников для недопредставленных категорий. Валидация feed URL. Хранение в `pending_sources.json`. Отправка approval-кнопок в Telegram. |
-| `markdown_writer.py` | Запись дайджеста в `digests/YYYY-MM-DD.md` с YAML front matter для Obsidian. |
+| `delivery/markdown.py` | Запись дайджеста в `digests/YYYY-MM-DD.md` с YAML front matter для Obsidian. |
 | `_dns_pinning.py` | SSRF-защита: DNS pinning для всех исходящих HTTP-запросов. Блокирует запросы к internal IP ranges (RFC1918). |
 | `_sanitize.py` | Очистка HTML/текста из feed-контента перед передачей в LLM. |
 | `_util.py` | `atomic_json_write()` — атомарная запись JSON через временный файл + rename, предотвращает корруп цию при сбое. |
@@ -182,7 +184,7 @@ calculate_effective_priorities() учитывает feedback_score
 
 ```
 1. DISCOVERY
-   python -m src --discover
+   python -m digest --discover
    → LLM генерирует кандидатов для категорий с < N источников
    → валидация feed URL (реальный HTTP-запрос)
    → сохранение в .cache/pending_sources.json
@@ -218,6 +220,8 @@ calculate_effective_priorities() учитывает feedback_score
 | `seen_articles.json` | `{md5_hash: iso_timestamp}` для дедупликации | Записи старше 7 дней удаляются при `save_dedup_cache()` |
 | `source_stats.json` | `SourceStats` per source с daily history | История ограничена 30 снапшотами; неактивные источники pruned |
 | `feedback.json` | `ArticleFeedback[]` + `last_update_id` + `article_source_map` | Оценки старше 30 дней; `article_source_map` ограничен 1000 записями |
+| `source_state.json` | `SourceStateEntry` per source: `trial_started`, `graduated`, `demoted` | Никогда не pruned автоматически; схема версионирована (`schema_version`) |
+| `source_category_map.json` | `{source_name: category}` — снапшот конфига для `/bubble` | Перезаписывается при каждом успешном pipeline-запуске |
 | `pending_sources.json` | Очередь кандидатов на добавление из `--discover` | Очищается после apply_trial_decisions() |
 
 Запись всех файлов — атомарная через `atomic_json_write()` (write tmp → rename), что предотвращает частичную запись при сбое процесса.
@@ -234,7 +238,7 @@ Concurrency: group=digest, cancel-in-progress=false
 
 Jobs:
   test:   ruff check → mypy → pytest → validate config
-  digest: (needs: test) → python -m src → git add digests/ .cache/ config.yaml → git push
+  digest: (needs: test) → python -m digest → git add digests/ .cache/ config.yaml → git push
 ```
 
 После запуска дайджест коммитится обратно в `main` с сообщением `digest: YYYY-MM-DD`. Перед push делается `git pull --rebase` для обработки concurrent writes (например, если discover и digest запустились одновременно).
@@ -247,7 +251,7 @@ Concurrency: group=digest, cancel-in-progress=false  (та же группа, ч
 
 Jobs:
   test:     ruff check → mypy → pytest
-  discover: (needs: test) → python -m src --discover → git add .cache/ → git push
+  discover: (needs: test) → python -m digest --discover → git add .cache/ → git push
 ```
 
 Та же concurrency group предотвращает одновременную запись в `.cache/` двумя workflow.
@@ -296,7 +300,7 @@ Feed-контент (title, description) очищается перед пере�
 
 ### /bubble команда в Telegram
 
-Отправьте `/bubble` боту — он ответит снапшотом фильтр-пузыря: диверсификация источников (Shannon entropy 0–100), топ-5 источников за последние 7 дней, статистика обратной связи за 14 дней, состояние lifecycle источников. Ответ формируется из локального кеша (без LLM и сетевых запросов) и приходит при следующем запуске pipeline.
+Отправьте `/bubble` боту — он ответит снапшотом фильтр-пузыря: диверсификация источников (Shannon entropy 0–100), разбивка по **категориям** за последние 7 дней (если `source_category_map.json` доступен; иначе топ-5 источников), статистика обратной связи за 14 дней, состояние lifecycle источников (graduated/trial/demoted). Ответ формируется из локального кеша (без LLM и сетевых запросов). Доступен только владельцу бота (`TELEGRAM_CHAT_ID`). Требует `adaptive.enabled: true` и хотя бы одного завершённого pipeline-запуска.
 
 ### Failure notification
 

--- a/docs/domain/digest/overview.md
+++ b/docs/domain/digest/overview.md
@@ -1,6 +1,14 @@
 # Bounded Context: Digest
 
-_Discovered: 2026-04-26. Domain discovery session with domain-researcher._
+_Discovered: 2026-04-26. Updated: 2026-04-28. Post-interview sections added from code._
+
+---
+
+## Purpose
+
+The Digest BC coordinates the full lifecycle of one operator's daily information intake: collecting articles from configured RSS sources, summarising them per category via LLM, and delivering the result to the operator via Telegram and Obsidian. Counter-signal discovery is delegated to the **Irritator BC** (a separate bounded context); the Digest BC invokes it as an upstream–downstream dependency and delivers its output alongside the main digest.
+
+**Explicitly outside scope:** full-text storage of raw articles (RSS providers own the content; BC stores only the hash for deduplication); user authentication/authorisation (single-owner system); push notifications policy (Telegram's concern); full-text search across digest history (Obsidian's concern); multi-user or multi-tenant scenarios.
 
 ---
 
@@ -8,11 +16,11 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 
 | Actor | Type | Role |
 |-------|------|------|
-| User | Human | Configures sources, reads digest, votes on articles |
+| User (Operator) | Human | Configures sources via `config.yaml`; reads digest; votes 👍/👎 on articles; approves/rejects discovered sources; requests `/bubble` and `/status` reports |
 | RSS Feed Providers | External system | Publishes Atom/RSS feeds consumed by Radar |
-| GitHub Actions | Scheduler | Triggers daily pipeline and weekly discovery |
-| Telegram Bot API | External system | Delivers digest to user, receives vote callbacks |
-| Obsidian Vault | External system | Consumes generated .md files per agreed format |
+| GitHub Actions | Scheduler | Triggers daily pipeline (`python -m digest`) and weekly source discovery (`--discover`) |
+| Telegram Bot API | External system | Delivers digest article cards and counter-signal posts; receives vote/approval callbacks; responds to bot commands |
+| Obsidian Vault | External system | Consumes generated `.md` files per agreed front-matter format |
 
 ---
 
@@ -22,13 +30,13 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 
 | Event | Aggregate owner | Module |
 |-------|----------------|--------|
-| FeedFetched | — (process event, no aggregate) | Radar |
+| FeedFetched | — (process event) | Radar.collector |
 | ArticleIngested | Article | Radar.collector |
 | ArticleFiltered | Article | Radar.collector |
-| SummaryGenerated | — (process event, no aggregate) | Radar.summarizer |
+| SummaryGenerated | — (process event) | Radar.summarizer |
 | NarrativeExtracted | — (transient, not persisted) | Irritator |
-| CounterSignalFound | — (transient, not persisted) | Irritator |
-| DigestDelivered | — (process event, no aggregate) | Delivery |
+| SignalFound | — (transient, not persisted) | Irritator |
+| DigestDelivered | — (process event) | Delivery |
 | FeedbackReceived | Source¹ | Delivery.telegram |
 | SourcePriorityUpdated | Source | Radar.collector (next run) |
 | TrialStarted | Source | Radar.collector |
@@ -37,8 +45,10 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 | SourceDiscovered | PendingSource | Discovery |
 | SourceApproved | PendingSource | Discovery |
 | SourceRejected | PendingSource | Discovery |
+| BubbleReportRequested | — (query, no state change) | Delivery.telegram |
+| BubbleReportGenerated | — (query result) | Delivery.telegram |
 
-**Blue — команды (с целевым агрегатом):**
+**Blue — команды:**
 
 | Command | Target aggregate | Module |
 |---------|----------------|--------|
@@ -46,36 +56,43 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 | SummarizeCategory | — | Radar.summarizer |
 | ExtractNarratives | — | Irritator |
 | GenerateQueries | — | Irritator |
-| SearchCounterSignals | — | Irritator.sources |
+| SearchAllSources | — | Irritator.sources |
 | DeliverDigest | — | Delivery |
 | UpdateSourcePriority | Source | Radar.collector |
 | EvaluateTrialSource | Source | Radar.collector |
 | DiscoverSources | PendingSource (creates) | Discovery |
 | ApproveSource | PendingSource → Source | Discovery |
 | RejectSource | PendingSource | Discovery |
+| RequestBubbleReport | — (query) | Delivery.telegram |
 
-**Lilac — политики (с модулем-исполнителем):**
-- Когда FeedbackReceived → UpdateSourcePriority (с 14-дневным затуханием). Исполнитель: Radar.collector при следующем pipeline-запуске. ¹ Ownership размазан: Delivery записывает, Radar применяет — hot spot #3.
-- Когда Trial активен 7+ дней → EvaluateTrialSource (graduated/demoted). Исполнитель: Radar.collector.
-- Когда Article старше 48 часов → ArticleFiltered. Исполнитель: Radar.collector.
-- Когда SourceApproved → AddSourceToConfig (добавляет trial-блок в config.yaml) → TrialStarted. Исполнитель: Discovery. ² Config.yaml мутируется runtime-ом — hot spot #1.
+**Lilac — политики:**
+
+- Когда `FeedbackReceived` → `UpdateSourcePriority` (14-дневное затухание). Исполнитель: Radar.collector при следующем pipeline-запуске. ¹ Ownership размазан: Delivery записывает, Radar применяет — hot spot #3.
+- Когда Trial активен ≥ `trial_days` дней → `EvaluateTrialSource` (graduated/demoted). Исполнитель: Radar.collector.
+- Когда Article старше 48 часов → `ArticleFiltered`. Исполнитель: Radar.collector.
+- Когда `SourceApproved` → `AddSourceToConfig` (добавляет trial-блок в `config.yaml`) → `TrialStarted`. Исполнитель: Discovery.
+- Когда delivery провалилась → откатить `FeedbackStore.last_update_id` и `ratings` до pre-run состояния. Исполнитель: main.py.
 
 **Yellow — агрегаты:**
-- **Source** — владеет: user_priority, enabled. Runtime-состояние (trial_started, graduated, demoted) хранится в `SourceStateStore` (`.cache/source_state.json`) — не на агрегате. ADR-0003. Эмитирует: TrialStarted, TrialGraduated, TrialDemoted, SourcePriorityUpdated. Команды: EvaluateTrialSource, UpdateSourcePriority.
-- **Article** — владеет: hash (identity), relevance_score, age, source_ref, delivered_flag. Эмитирует: ArticleIngested, ArticleFiltered. Команды: FetchFeeds.
-- **PendingSource** — владеет: name, url, category, discovered_at, source_hash. Lifecycle: discovered → approved/rejected. Утверждение через Telegram-кнопки. Одобрение мутирует `config.yaml` (добавляет trial-блок) и запускает TrialStarted. Команды: ApproveSource, RejectSource.
 
-> **Trial state вне Source (ADR-0003):** trial_started, graduated, demoted хранятся в SourceStateStore, а не в Source aggregate. Это позволяет config.yaml оставаться декларативным. Если появится потребность transact trial state вместе с другими полями Source — пересмотреть.
+- **Source** — владеет: `user_priority`, `enabled`. Runtime-состояние (`trial_started`, `graduated`, `demoted`) хранится в `SourceStateStore` (`.cache/source_state.json`) — не на агрегате (ADR-0003).
+- **Article** — владеет: `hash` (identity), `relevance_score`, `age`, `source_ref`, `delivered_flag`.
+- **PendingSource** — владеет: `name`, `url`, `category`, `discovered_at`, `source_hash`. Lifecycle: `discovered → approved/rejected`.
+
+> **Trial state вне Source (ADR-0003):** `trial_started`, `graduated`, `demoted` хранятся в `SourceStateStore`, позволяя `config.yaml` оставаться декларативным.
 
 **Green — read models:**
-- SourceLeaderboard (для UI настройки приоритетов — будущее)
-- DigestHistory (для Obsidian — формат .md подчинён ожиданиям Obsidian, см. Context Map)
+
+- `BubbleReport` — снимок filter bubble: diversity score (Shannon entropy по 7-дневным включениям статей), топ-категории по объёму, счётчики feedback за 14 дней, trial/graduated/demoted источники. Генерируется on-demand по команде `/bubble`.
+- `DigestHistory` — `.md`-файлы в Obsidian (формат подчинён ожиданиям Obsidian).
+- `NanoStatus` — двухстрочный footer каждого дайджеста: кол-во источников/статей, LLM-провайдер, promoted/demoted счётчики, средний score источников.
 
 **Red — горячие точки:**
-1. **Source dual-storage**: `config.yaml` мутируется двумя независимыми runtime-путями: (a) `apply_trial_decisions()` в `source_scorer.py` пишет trial/enabled-флаги, (b) `add_source_to_config()` в `discovery.py` добавляет новые trial-блоки. ADR-0003 перенёс часть состояния в `.cache/source_state.json`, но оба write-пути в config.yaml остались. Нет единого владельца. → Issue #37.
-2. **Article без явного lifecycle**: нет состояний raw → scored → delivered → archived. Дедупликация через hash в кеше — ad-hoc решение. → Issue #39.
-3. **Feedback decay owner**: логика затухания размазана между Delivery (запись feedback) и Radar (применение при следующем запуске). Политика задекларирована, но исполнитель распределён. → Issue #40.
-4. **Radar→Delivery contract drift**: CategorySummary расширяется набором ArticleSummary для рендера индивидуальных постов в Telegram. Delivery начинает зависеть от структурированного списка статей с per-article саммари в дополнение к агрегированному тексту категории. Без явного внутрифазового контракта изменения в Radar могут молча ломать Delivery. → Issue #29.
+
+1. **Source dual-storage**: `config.yaml` мутируется двумя путями: `apply_trial_decisions()` и `add_source_to_config()`. Нет единого владельца. → Issue #37.
+2. **Article без явного lifecycle**: нет состояний `raw → scored → delivered → archived`. Дедупликация через hash — ad-hoc. → Issue #39.
+3. **Feedback decay owner**: логика затухания размазана между Delivery (запись) и Radar (применение). → Issue #40.
+4. **Radar→Delivery contract drift**: `CategorySummary` расширяется `ArticleSummary`-набором без явного внутрифазового контракта. → Issue #29.
 
 ---
 
@@ -84,38 +101,48 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 **В scope:**
 - Сбор статей из RSS (Radar)
 - Фильтрация и оценка релевантности по контексту пользователя
-- Дедупликация Article по hash (identity state — внутри BC)
+- Дедупликация Article по hash
 - Генерация нарративов и поиск контрсигналов (Irritator)
 - Доставка через Telegram и запись в Obsidian (Delivery)
 - Адаптивная система приоритетов источников (trial + feedback)
 - Обнаружение и одобрение новых источников (Discovery)
+- Filter bubble аналитика (BubbleReport)
 
 **Намеренно вне scope:**
-- Полнотекстовое хранилище сырых статей (RSS-провайдеры ответственны за контент; BC хранит только hash для дедупликации)
+- Полнотекстовое хранилище сырых статей
 - Политика уведомлений пользователя (Telegram's concern)
 - Полнотекстовый поиск по истории дайджестов (Obsidian's concern)
-- Аутентификация и авторизация (нет пользователей, кроме владельца)
+- Аутентификация и авторизация
 
 **Термин, меняющий смысл на границе:**
-`Article` — на стороне RSS это XML-запись без контекста. После пересечения границы BC Article приобретает `relevance_score`, `age`, `source_ref` и становится объектом с lifecycle. Пересечение = момент ingestion в Radar.collector.
+`Article` — на стороне RSS это XML-запись без контекста. После ingestion в Radar.collector Article приобретает `relevance_score`, `age`, `source_ref`.
 
 ---
 
-## Ubiquitous Language
+## Aggregate Root
 
-| Term | Business definition | Aliases to avoid |
-|------|---------------------|------------------|
-| **Source** | Информационный канал (RSS URL), за которым система наблюдает; имеет user_priority (задан вручную). Runtime-приоритет вычисляется из Feedback при каждом запуске — не хранится на Source. ADR-0003. | Feed, Channel |
-| **Article** | Единица контента, прошедшая границу BC: имеет relevance_score, возраст и принадлежность к Source. До ingestion — это XML-запись, не Article. | Item, Post, Entry |
-| **Trial** | Испытательный период нового источника (pending → active → graduated/demoted). Runtime-состояние хранится в SourceStateStore, не в Source aggregate (ADR-0003). | Probation, Test |
-| **Narrative** | Доминирующая тема, выявленная из группы Articles одного pipeline-запуска. Не персистируется — существует только в памяти во время запуска. | Topic, Theme, Category |
-| **Feedback** | Явный сигнал пользователя (👍/👎) об Article в Telegram; влияет на эффективный приоритет Source с экспоненциальным затуханием за 14 дней. Feedback без decay — устаревший сигнал. | Vote, Rating, Reaction |
-| **Digest** | Результат одного pipeline-запуска: набор Narratives с Articles, доставленный через один или несколько каналов (Telegram + Obsidian) в конкретный момент времени. Не является архивом — это event. | Report, Summary, Run |
-| **CounterSignal** | Статья или дискуссия из внешней платформы (HN, Reddit, arXiv, …), найденная Irritator-ом как альтернативная точка зрения на Narrative. Не является частью основного Source-набора. | Alternative, Counterpoint |
-| **PendingSource** | Кандидат в Sources, обнаруженный Discovery-фазой и ожидающий одобрения оператором через Telegram. Существует только до момента Approve/Reject — не становится Source напрямую, а инициирует TrialStarted. | Candidate, Suggestion |
-| **CategorySummary** | Сгруппированный результат фазы Radar для одной таксономической категории источников (например, «AI & LLM», «Security» — классификация Sources, а не тематика Narratives): объединяет аналитический текст по категории и набор ArticleSummary для индивидуальной подачи. Является контрактом передачи данных от Radar к Delivery внутри одного pipeline-запуска. | Section, Bucket |
-| **ArticleSummary** | Сгенерированное LLM саммари одной конкретной статьи в 1-2 предложения, раскрывающее нетривиальный или неочевидный аспект новости для Technology Architect, а не просто пересказывающее заголовок. Часть CategorySummary; используется Delivery для рендера индивидуальных постов (отдельных Telegram-сообщений с кнопками голосования). | Article comment, Blurb |
-| **Perspectives** | Три аналитические точки зрения на наиболее значимые события в категории — Оптимист (🟢), Скептик (🔴), Реалист (⚖️). Должны представлять принципиально разные цепочки рассуждений, а не разный тон. Часть аналитического текста CategorySummary, не отдельная сущность. Применяются только в развёрнутых стилях дайджеста, не в кратком. | Viewpoints, Stances, Voices |
+**Source**
+- Инварианты: `priority` ∈ [1..10]; `url` является валидным HTTP/HTTPS URL; `name` уникален среди enabled sources; demoted source не участвует в pipeline (фильтруется в `main.py` через `source_state.is_demoted()`).
+- Runtime-состояние trial в `SourceStateStore`, не на агрегате.
+
+**Article**
+- Инварианты: `hash` = SHA-256 первых 500 символов description + title; одна и та же пара (hash, source) никогда не ingested дважды в рамках `CACHE_MAX_AGE_DAYS=7`; `pub_date` старше 48 часов → Article не ingested.
+
+**PendingSource**
+- Инварианты: `source_hash` уникален в pending-списке; `url` прошёл SSRF-валидацию (`_dns_pinning.validate_url`) до попадания в pending.
+
+---
+
+## Policies
+
+| Trigger | Action | Executor |
+|---------|--------|----------|
+| `FeedbackReceived` | `UpdateSourcePriority` с 14-дневным затуханием | Radar.collector, следующий запуск |
+| Trial активен ≥ `trial_days` И `calculate_score > 0.6` | `TrialGraduated` | Radar.collector |
+| Trial активен ≥ `trial_days` И `calculate_score < 0.3` | `TrialDemoted` | Radar.collector |
+| Article `pub_date > 48h` | `ArticleFiltered` | Radar.collector |
+| `SourceApproved` | Добавить trial-блок в `config.yaml`, эмитировать `TrialStarted` | Discovery |
+| `delivery_ok == False` | Откатить `FeedbackStore` до pre-run состояния | main.py |
 
 ---
 
@@ -123,23 +150,256 @@ _Discovered: 2026-04-26. Domain discovery session with domain-researcher._
 
 | Upstream BC / System | Pattern | Notes |
 |----------------------|---------|-------|
-| RSS Feed Providers | **Conformist** | Потребляем их формат (Atom/RSS) через feedparser. Мы подстраиваемся — они не знают о нас. |
-| Telegram Bot API | **Conformist** | Используем их Published Language (MarkdownV2, inline keyboards, callback queries). Мы на их условиях. |
-| HN / Reddit / arXiv / dev.to / Lobsters | **Conformist** | Читаем их публичные API без контракта. Breakage возможен при изменении их API. |
-| Obsidian Vault | **Customer-Supplier** | Obsidian — downstream customer: формат .md (заголовки, ссылки, теги) подчинён его ожиданиям. Digest — supplier. DigestHistory — Published Language этой связи. |
+| RSS Feed Providers | **Conformist** | Потребляем Atom/RSS через feedparser; подстраиваемся под их формат |
+| Telegram Bot API | **Conformist** | Используем их Published Language (MarkdownV2, inline keyboards, callback queries) |
+| HN / Reddit / arXiv / dev.to / Lobsters | **Conformist** | Читаем публичные API без контракта; breakage возможен при изменении API |
+| Obsidian Vault | **Customer-Supplier** | Obsidian — downstream customer; формат `.md` подчинён его ожиданиям; Digest — supplier |
 
 ---
 
-## Areas of Unclear Ownership (documented, not ticketed)
+## Use Cases
 
-Эти смысловые расхождения зафиксированы как технический долг — не как active issues:
+### UC-1: Ежедневный запуск пайплайна
 
-- **Feedback decay owner**: логика затухания (14 дней) объявлена в политике, но исполнена в двух модулях: Delivery записывает feedback, Radar читает и применяет при следующем запуске. Единого aggregate нет.
-- **Article lifecycle**: нет явных состояний между ingestion и archival. Если появится потребность в replay или ручном редактировании — нужна модель.
-- **Narrative transience**: не персистируется между запусками. Если понадобится трендовый анализ — придётся добавлять persistence.
+**Actor:** GitHub Actions (Scheduler)
+**Preconditions:** `config.yaml` существует и валиден; LLM API key доступен; `TELEGRAM_BOT_TOKEN` и `TELEGRAM_CHAT_ID` установлены.
+**Main scenario:**
+1. `collect_feedback()` опрашивает Telegram getUpdates; новые votes и approval-решения записываются в `FeedbackStore`.
+2. `calculate_effective_priorities()` пересчитывает приоритеты источников.
+3. `collect()` фетчит RSS-фиды параллельно; новые Articles дедуплицируются по hash.
+4. `summarize_all()` суммаризирует каждую категорию через LLM; для ≥1 топ-тем генерирует три перспективы (Optimist/Skeptic/Realist) если `summary_style != brief`.
+5. `run_irritator()` извлекает нарративы → генерирует adversarial-запросы → ищет контрсигналы → валидирует → ранжирует.
+6. `write_digest()` сохраняет `.md` в Obsidian.
+7. `send_article_cards()` публикует individual Telegram posts с кнопками 👍/👎.
+8. `send_counter_signals()` публикует контрсигналы с IrritatorStatus footer.
+9. `evaluate_trial_sources()` принимает решения о graduated/demoted.
+10. Все сторы персистируются атомарно.
+
+**Alternatives:**
+- 3a: Все фиды недоступны → `AllFeedsFailedError` → пайплайн завершается с кодом 1.
+- 3b: Нет новых статей → пайплайн завершается успешно, без доставки.
+- 5a: Irritator pipeline пуст → `IrritatorStatus.level == "empty"` → контрсигналы не публикуются.
+- 7a: Telegram delivery провалилась → `FeedbackStore` откатывается; оба delivery failures → exit code 1.
+
+**Postconditions:** `feedback.json`, `source_state.json`, `source_stats.json`, `source_category_map.json` обновлены; `.md`-файл создан; Telegram messages отправлены; dedup cache обновлён.
 
 ---
 
-## Recommended Next Action
+### UC-2: Пользователь голосует за статью
 
-**Issue #39** — Article lifecycle (act when replay/trend analysis is needed). **Issue #40** — Feedback decay owner consolidation (act when decay formula changes). Both are correctly deferred with explicit trigger conditions.
+**Actor:** User (через Telegram inline button)
+**Preconditions:** Article card уже доставлена с кнопками `fb:a:g:{hash}` / `fb:a:b:{hash}`; `article_source_map` содержит `hash → source_name`.
+**Main scenario:**
+1. Пользователь нажимает 👍 или 👎.
+2. На следующем запуске `collect_feedback()` получает callback query.
+3. Парсинг `callback_data = "fb:a:{g|b}:{article_hash}"` → `rating = +1 / -1`.
+4. `ArticleFeedback(article_hash, source_name, rating, timestamp)` добавляется в `FeedbackStore.ratings`.
+5. Telegram callback query отвечается (loading indicator сбрасывается).
+
+**Alternatives:**
+- 3a: `article_source_map` miss для `hash` → `ArticleFeedback` записывается с `source_name=""`, логируется warning.
+- 4a: Feedback запись от > 30 дней назад → будет pruned при следующем `save_feedback()`.
+
+**Postconditions:** `FeedbackStore` содержит новый `ArticleFeedback`; при следующем запуске он влияет на `effective_priorities` этого источника.
+
+---
+
+### UC-3: Пользователь запрашивает filter bubble отчёт
+
+**Actor:** User (Telegram command `/bubble`)
+**Preconditions:** Хотя бы один запуск пайплайна был завершён; `.cache/source_stats.json`, `.cache/source_state.json`, `.cache/source_category_map.json` существуют.
+**Main scenario:**
+1. `collect_feedback()` получает message `text="/bubble"`.
+2. Загружаются `stats`, `state`, `category_map` из `.cache/`.
+3. `compute_bubble_report()` вычисляет: дата последнего дайджеста, `_diversity_score()` (Shannon entropy), топ-категории по 7-дневным включениям, feedback за 14 дней, trial/graduated/demoted счётчики.
+4. Отчёт отправляется в тот же chat.
+
+**Alternatives:**
+- 2a: `.cache/`-файлы отсутствуют → `compute_bubble_report()` возвращает отчёт с нулями.
+
+**Postconditions:** Пользователь получил read-only снимок своего информационного пузыря; состояние системы не изменилось.
+
+---
+
+### UC-4: Оператор одобряет/отклоняет новый источник
+
+**Actor:** User (Telegram inline button)
+**Preconditions:** Discovery phase (`--discover`) нашла новый источник и отправила approval message с кнопками `src:ok:{hash}` / `src:no:{hash}`; PendingSource сохранён в `.cache/pending_sources.json`.
+**Main scenario:**
+1. Пользователь нажимает "✅ Добавить" или "❌ Отклонить".
+2. На следующем запуске `collect_feedback()` парсит `callback_data = "src:{ok|no}:{source_hash}"`.
+3. Решение записывается в `FeedbackStore.source_decisions`.
+4. `_process_pending_approvals()` загружает pending список, находит соответствие по `source_hash`.
+5. Если approved: `add_source_to_config()` добавляет trial-блок в `config.yaml`; `TrialStarted` эмитируется на следующем запуске.
+6. Если rejected: PendingSource удаляется из pending.
+
+**Alternatives:**
+- 4a: PendingSource уже удалён (например, отклонён ранее) → решение игнорируется.
+- 5a: `add_source_to_config()` падает → ошибка логируется, PendingSource остаётся в pending.
+
+**Postconditions:** `config.yaml` обновлён (approved) или PendingSource удалён (rejected).
+
+---
+
+### UC-5: Trial source evaluation (graduated/demoted)
+
+**Actor:** GitHub Actions (Scheduler, автоматически в конце pipeline)
+**Preconditions:** В `config.yaml` есть источник с `trial: true`; `SourceStateStore` содержит `trial_started`; прошло ≥ `trial_days` дней.
+**Main scenario:**
+1. `evaluate_trial_sources()` читает `SourceStateStore` и `SourceStats`.
+2. Для каждого trial-источника вычисляет `calculate_score()` (reliability 30% + productivity 30% + desc_quality 20% + recency 20%).
+3. `score > 0.6` → `TrialGraduated`: `SourceStateStore.mark_graduated(name)`.
+4. `score < 0.3` → `TrialDemoted`: `SourceStateStore.mark_demoted(name)`; источник исключается из следующих запусков.
+5. `SourceStateStore` сохраняется.
+
+**Alternatives:**
+- 2a: `score` ∈ [0.3..0.6] → источник остаётся в trial ещё один цикл.
+- 3a: Источник уже graduated/demoted → пропускается.
+
+**Postconditions:** `source_state.json` обновлён; demoted источник не участвует в следующем pipeline-запуске.
+
+---
+
+## Domain Data Model
+
+### Article
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `title` | str | непустой |
+| `link` | str | валидный URL |
+| `description` | str | max 500 символов после sanitize |
+| `source` | str | существует в `config.sources` |
+| `category` | str | существует в `config.sources` |
+| `pub_date` | `datetime \| None` | если известна, не старше 48 часов (иначе filtered) |
+
+Состояния: `raw` (из feedparser) → `ingested` (прошёл dedup + age + blocklist) → `summarized` (включён в `CategorySummary`). Архивирование — через dedup cache TTL 7 дней.
+
+### CategorySummary
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `category` | str | |
+| `summary_text` | str | прошёл `_clean_summary()` |
+| `article_count` | int | ≥ 1 |
+| `article_summaries` | `list[ArticleSummary]` | пустой список если per-article summaries не запрошены |
+
+### ArticleSummary
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `title` | str | |
+| `link` | str | |
+| `source` | str | |
+| `category` | str | |
+| `summary` | str | ≤ 2 предложения; раскрывает нетривиальный/неочевидный аспект (бизнес-правило, зафиксировано в UL) |
+
+### Source (aggregate)
+
+Хранится декларативно в `config.yaml`. Runtime-состояние в `SourceStateStore`.
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `name` | str | уникален среди enabled sources |
+| `url` | str | HTTP/HTTPS, прошёл SSRF-валидацию |
+| `category` | str | |
+| `priority` | int | [1..10] |
+| `enabled` | bool | |
+| `trial` | bool | |
+| `trial_days` | int | > 0 если `trial=true` |
+
+Runtime state (`SourceStateEntry`): `trial_started: str | None`, `graduated: bool`, `demoted: bool`.
+
+### FeedbackStore
+
+Персистируется в `.cache/feedback.json`. Prunes ratings > 30 дней; `article_source_map` capped at 1000 entries.
+
+| Field | Type |
+|-------|------|
+| `ratings` | `list[ArticleFeedback]` |
+| `last_update_id` | int (Telegram update ID cursor) |
+| `last_digest_sources` | `list[str]` |
+| `last_digest_time` | str (ISO) |
+| `source_decisions` | `dict[source_hash, "approved"\|"rejected"]` |
+| `article_source_map` | `dict[article_hash_8, source_name]` |
+
+### SourceStats
+
+Персистируется в `.cache/source_stats.json`. History capped at 30 дней.
+
+| Field | Type |
+|-------|------|
+| `name` | str |
+| `total_fetches`, `successful_fetches` | int |
+| `total_articles_found`, `articles_included_in_digest` | int |
+| `avg_description_length` | float (EMA, alpha=0.3) |
+| `last_seen` | `str \| None` |
+| `history` | `list[DailySnapshot]` (max 30) |
+
+---
+
+### BubbleReport (read model)
+
+Генерируется on-demand по команде `/bubble`. Не персистируется — вычисляется из `.cache/`-файлов каждый раз.
+
+| Field | Type | Source |
+|-------|------|--------|
+| `generated_at` | str (UTC) | `datetime.now()` |
+| `last_digest_time` | str | `FeedbackStore.last_digest_time` |
+| `diversity_score` | float [0..100] | Shannon entropy по 7-дневным включениям статей по источникам |
+| `diversity_label` | `"Diverse"\|"Moderate"\|"Concentrated"` | score ≥ 70 → Diverse; ≥ 40 → Moderate; иначе Concentrated |
+| `category_breakdown` | `dict[category, count]` (7d) | `source_category_map` + `SourceStats.history` |
+| `feedback_summary` | `(total, positive, negative)` (14d) | `FeedbackStore.ratings` |
+| `trial_summary` | `(graduated, trial, demoted)` | `SourceStateStore` |
+
+---
+
+## Interface Contracts
+
+| Interface | Direction | Protocol | Operations | Handled failures | Unhandled failures |
+|-----------|-----------|----------|-----------|------------------|--------------------|
+| RSS Feed Providers | inbound | HTTP/HTTPS + feedparser | GET feed URL | timeout → source marked error; `feedparser.bozo` + empty entries → warn | SSL errors, schema changes в XML |
+| Telegram Bot API (delivery) | outbound | HTTPS REST | `sendMessage` (MarkdownV2), `sendMessage` (inline keyboard) | HTTP 4xx → logged warning, non-critical | Bot token revoked |
+| Telegram Bot API (feedback) | inbound | HTTPS polling | `getUpdates` + `answerCallbackQuery` + `deleteWebhook` | webhook active → auto-delete before polling; 0 results → info log | Rate limiting, update_id skew |
+| Irritator sources (HN/Reddit/arXiv/devto/Lobsters) | outbound | HTTPS REST | search queries (per-adapter) | per-adapter exceptions caught; empty results → continue | API schema changes |
+| Obsidian Vault | outbound | filesystem | atomic write `.md` to configured path | write error → `markdown_saved=False` | Obsidian plugin format changes |
+| LLM providers (Groq/Gemini/DeepSeek/Anthropic/Mistral) | outbound | HTTPS REST | chat completion | provider exception → logged, category skipped | API key invalid, quota exceeded |
+
+---
+
+## NFR
+
+Только механически-проверяемые ограничения:
+
+| Constraint | Enforcement | Artifact |
+|------------|-------------|----------|
+| HTTP calls go through SSRF guard | `_dns_pinning.validate_url()` rejects private/local ranges | `digest/_dns_pinning.py` |
+| HTML/script injection stripped from feed content | `_sanitize.sanitize_article()` | `digest/_sanitize.py` |
+| JSON writes are atomic (no partial writes) | `atomic_json_write()` uses tmp + rename | `digest/_util.py` |
+| Cache entries cap at 5000 / 7 days | `CACHE_MAX_ENTRIES=5000`, `CACHE_MAX_AGE_DAYS=7` | `radar/collector.py` |
+| Feedback ratings pruned at 30 days | `save_feedback()` prune loop | `feedback.py` |
+| `article_source_map` capped at 1000 entries | FIFO prune in `save_feedback()` | `feedback.py` |
+| ArticleSummary truncated at 2 sentences | `_cap_sentences(text, 2)` | `radar/summarizer.py` |
+
+---
+
+## Internal Compliance
+
+| Norm | Enforcement type | Artifact | Honor-system gap? |
+|------|-----------------|----------|-------------------|
+| Type hints on all functions | mypy strict | `Makefile typecheck`, CI | No — CI blocks merge |
+| No unused imports | ruff F401 | `.pre-commit-config.yaml`, CI | No — pre-commit + CI |
+| async/await for all I/O | mypy + code review | — | Yes — no static check for sync I/O calls |
+| Dataclasses for data structures | code review | — | Yes |
+| No real HTTP in tests | pytest fixture convention | `tests/` mock patterns | Yes — no network isolation in CI |
+| Config YAML only | convention | CLAUDE.md | Yes |
+| English for log/error messages | code review | CLAUDE.md | Yes |
+
+---
+
+## Red Hotspots
+
+1. **Source dual-storage**: `config.yaml` мутируется двумя независимыми runtime-путями. → Issue #37.
+2. **Article без явного lifecycle**: нет типизированных состояний между ingestion и archival. → Issue #39.
+3. **Feedback decay owner**: логика затухания распределена между Delivery и Radar. → Issue #40.
+4. **Radar→Delivery contract drift**: нет явного внутрифазового контракта между Radar и Delivery. → Issue #29.

--- a/docs/domain/irritator-bc.md
+++ b/docs/domain/irritator-bc.md
@@ -1,4 +1,10 @@
-# Bounded Context: Irritator
+# Bounded Context: Irritator — ARCHIVED DIAGNOSTIC
+
+> **Superseded.** This document is a historical diagnostic report written in April 2026.
+> The canonical BC overview is at **[docs/domain/irritator/overview.md](irritator/overview.md)**.
+> Keep this file for its failure-mode analysis (§§ marked [UPDATED — issue #53]); do not update it.
+
+---
 
 **Purpose:** Given the day's news summaries, surface external content that meaningfully challenges, contradicts, or complicates the dominant narratives the operator is being fed — i.e. break the bubble.
 

--- a/docs/domain/irritator/overview.md
+++ b/docs/domain/irritator/overview.md
@@ -1,0 +1,336 @@
+# Bounded Context: Irritator
+
+_Discovered: 2026-04-28. Migrated and extended from `irritator-bc.md` (written against commit `cc974f5`; issue-#53 fixes incorporated)._
+
+---
+
+## Purpose
+
+The Irritator BC owns the problem of breaking the operator's filter bubble. Given the day's news summaries, it surfaces external content that meaningfully challenges, contradicts, or complicates the dominant narratives the operator is being fed.
+
+**Explicitly outside scope:** generating the summaries (Radar's concern); formatting and delivering results to the operator (Delivery's concern); storing feedback about whether a counter-signal was useful (Delivery/Feedback's concern); modelling the operator's bubble across runs (no persistent bubble fingerprint today — red hotspot).
+
+---
+
+## Actors
+
+| Actor | Type | Role |
+|-------|------|------|
+| Radar BC | Upstream service | Produces `list[CategorySummary]` — the day's summarised news, which is also the bubble to challenge |
+| LLM Provider | External system | Executes narrative extraction, query generation, and signal ranking |
+| External search platforms (HN, Reddit, arXiv, dev.to, Lobsters) | External systems | Provide raw signals in response to adversarial queries |
+| Delivery BC | Downstream service | Consumes `(list[Narrative], list[RankedSignal], IrritatorStatus)` for rendering |
+| Operator (indirect) | Human | Configured `IrritatorConfig` determines behaviour; feedback loop from operator votes is not yet wired |
+
+---
+
+## Events (Event Storming)
+
+**Orange — что произошло:**
+
+| Event | Aggregate owner | Stage |
+|-------|----------------|-------|
+| NarrativeExtracted | — (transient) | Stage 1 |
+| QueryGenerated | — (transient) | Stage 2 |
+| SignalFound | — (transient) | Stage 3 |
+| SignalFiltered | — (dedup/blocklist) | Stage 4 |
+| SignalRanked | — (transient) | Stage 5 |
+| IrritatorCompleted | — (process event) | Orchestrator |
+| IrritatorEmptied | — (process event, nothing survived) | Orchestrator |
+| IrritatorFailed | — (stage raised exception) | Orchestrator |
+
+**Blue — команды:**
+
+| Command | Handler |
+|---------|---------|
+| ExtractNarratives | `narrative_extractor.extract_narratives()` |
+| GenerateQueries | `query_generator.generate_queries()` |
+| SearchAllSources | `sources.search_all_sources()` |
+| ValidateSignals | `validator.validate_signals_async()` |
+| RankSignals | `ranker.rank_signals()` |
+
+**Lilac — политики:**
+
+- Когда `NarrativeExtracted` → `GenerateQueries` per narrative, параллельно.
+- Когда `QueryGenerated` → `SearchAllSources` (fan-out: каждый запрос × все configured sources).
+- Когда `SignalFound` → `ValidateSignals` (dedup by URL + blocklist + optional HEAD liveness check).
+- Когда `ValidatedSignal` → `RankSignals` per narrative (ALL validated signals ranked against EACH narrative — hot spot: provenance dropped).
+- Когда `RankedSignal.score < min_signal_score` → отброшен.
+
+**Yellow — агрегаты:**
+
+Нет персистируемых агрегатов. Весь pipeline transient — данные живут только в памяти одного запуска.
+
+**Green — read models:**
+
+- `IrritatorStatus` — оператору: funnel counters (`N narratives, M signals, K valid, J passed ranking`), level = ok/empty/error.
+
+**Red — горячие точки:**
+
+1. **Provenance dropped at search**: `search_all_sources()` флатенит результаты всех запросов в один `list[Signal]`. Связь `Signal → SearchQuery → Narrative` теряется. Ranking работает по принципу all-pairs: каждый нарратив ранжируется против всего пула сигналов.
+2. **Narrative без dominance/confidence**: `Narrative` не несёт доказательств консенсуса. Один абзац одной статьи неотличим от утверждения, повторяемого 12 источниками.
+3. **Нет bubble fingerprint**: Irritator не знает об операторе ничего, кроме сегодняшних сводок. Каждый запуск стартует холодно.
+4. **Source-narrative fit unmodelled**: все sources получают одинаковые запросы; нет SourceProfile.
+5. **"empty" без кода причины**: `IrritatorStatus.level == "empty"` покрывает три разных ситуации: off-topic signals, on-topic но ниже порога, нет сигналов вообще.
+
+---
+
+## Boundary
+
+**В scope:**
+- Извлечение доминирующих нарративов из `CategorySummary`-набора
+- Генерация adversarial search queries для каждого нарратива
+- Поиск сигналов по внешним платформам
+- Валидация (dedup by URL, blocklist, опциональный liveness check)
+- Ранжирование сигналов по силе противоречия нарративу
+
+**Намеренно вне scope:**
+- Персистенция нарративов или сигналов между запусками
+- Форматирование и доставка результатов (Delivery's concern)
+- Учёт feedback от оператора (Delivery/Feedback hot spot #3 из Digest BC)
+- Профилирование информационной диеты оператора
+
+**Термин, меняющий смысл на границе:**
+`Signal` — на стороне внешних платформ это search hit с popularity score (HN points, Reddit upvotes и т.д.). После пересечения в `rank_signals()` `Signal` оценивается по `contradiction_score` (1–10) — противоположная семантика. Тот же тип данных, разные системы координат.
+
+---
+
+## Aggregate Root
+
+Irritator не имеет персистируемых агрегатов. Границы инвариантов — на уровне одного pipeline-запуска:
+
+- `Narrative` должен содержать `claim`, `category`, `implicit_assumptions[]`, `why_worth_challenging` — иначе LLM ответ отброшен парсером.
+- `Signal` дедуплицируется по lower-cased, trailing-slash-stripped URL. First wins.
+- Blocklist match — case-insensitive substring по `title + snippet`.
+- `RankedSignal` принимается только если `score ≥ min_signal_score` (default = 5).
+- `IrritatorStatus.level = "error"` только если stage raised exception; пустые результаты → `"empty"`, не `"error"`.
+
+---
+
+## Policies
+
+| Trigger | Action |
+|---------|--------|
+| Все stages завершились, `all_ranked` непустой | `IrritatorStatus(level="ok")` |
+| Любой stage вернул пустой список | `IrritatorStatus(level="empty")` |
+| Stage raised exception | Ошибка логируется; если это Stage 1–2 — early return; если Stage 5 — ranking для этого narrative пропускается |
+| `RankedSignal.score < min_signal_score` | Сигнал отброшен |
+| URL уже видели в текущем запуске | `SignalFiltered` (dedup) |
+| Title/snippet содержит blocklist keyword | `SignalFiltered` |
+
+---
+
+## Context Map
+
+| System | Pattern | Notes |
+|--------|---------|-------|
+| Radar BC | **Conformist** | Irritator потребляет `CategorySummary` напрямую, без ACL. Radar меняет контракт — Irritator молча ломается. Irritator не имеет влияния на upstream. |
+| LLM Providers | **Conformist** | Используем их API; prompt engineering на нашей стороне |
+| HN / Reddit / arXiv / dev.to / Lobsters | **Conformist** | Публичные API без контракта; breakage возможен |
+| Delivery BC | **Customer-Supplier** | Irritator upstream supplier; Delivery downstream customer. Контракт: `(list[Narrative], list[RankedSignal], IrritatorStatus)` |
+
+---
+
+## Use Cases
+
+### UC-1: Полный Irritator pipeline (happy path)
+
+**Actor:** Digest main pipeline (программный вызов `run_irritator()`)
+**Preconditions:** `summaries: list[CategorySummary]` непустой; LLM API доступен; хотя бы один source в `IrritatorConfig.sources`.
+**Main scenario:**
+1. `extract_narratives(summaries, config)` → LLM возвращает ≤ `max_narratives` нарративов с полями `claim`, `category`, `implicit_assumptions`, `why_worth_challenging`.
+2. `generate_queries(narratives, config)` → для каждого нарратива параллельно генерируется `queries_per_narrative` adversarial SearchQuery с explicit negation/failure phrasing.
+3. `search_all_sources(all_queries, config, client)` → fan-out: каждый query × все configured sources; результаты флатенятся в `list[Signal]`.
+4. `validate_signals_async(signals, blocklist, client, check_liveness)` → dedup by URL + blocklist filter + optional HEAD liveness. Остаток: `list[Signal]`.
+5. Для каждого нарратива: `rank_signals(narrative, signals, config)` → LLM оценивает каждый сигнал по single criterion ("насколько сильно это ПРОТИВОРЕЧИТ нарративу?") с calibration anchors 9-10/7-8/5-6/1-4. Сигналы с `score < min_signal_score` отброшены; топ `top_signals` возвращаются как `list[RankedSignal]`.
+6. `IrritatorStatus(level="ok")` с funnel counters.
+
+**Alternatives:**
+- 1a: LLM не вернул ни одного нарратива → `IrritatorStatus(level="empty", text="0 narratives from N summaries")`.
+- 3a: Все sources вернули пустые результаты → `IrritatorStatus(level="empty")`.
+- 4a: Все сигналы отфильтрованы (dedup/blocklist) → `IrritatorStatus(level="empty")`.
+- 5a: Все сигналы ниже `min_signal_score` → `IrritatorStatus(level="empty")`.
+- 5b: Ranking упал для одного нарратива → ошибка логируется, остальные нарративы продолжают.
+
+**Postconditions:** Возвращается `(list[Narrative], list[RankedSignal], IrritatorStatus)`. Ничего не персистируется.
+
+---
+
+### UC-2: Все сигналы ниже порога
+
+**Actor:** Digest pipeline
+**Preconditions:** Pipeline прошёл stages 1–4 успешно; `valid_signals` непустой.
+**Main scenario:**
+1. `rank_signals()` отрабатывает для каждого нарратива.
+2. Все `RankedSignal.score < min_signal_score`.
+3. `all_ranked` остаётся пустым.
+4. `IrritatorStatus(level="empty", text="N narratives, M signals, K valid, 0 passed ranking")`.
+
+**Postconditions:** Delivery получает пустой список сигналов + `IrritatorStatus.level="empty"`. Delivery не отправляет counter-signals post.
+
+---
+
+### UC-3: Stage падает с исключением
+
+**Actor:** Digest pipeline
+**Preconditions:** LLM API недоступен или внешний source вернул неожиданный формат.
+**Main scenario:**
+1. Stage 1 (extract_narratives) поднимает исключение.
+2. Исключение поймано в orchestrator: `IrritatorStatus(level="error", text="narrative extraction failed: <exc>")`.
+3. Early return: `([], [], status)`.
+
+**Alternatives:**
+- Stage 3 (search) падает → возвращаются уже извлечённые нарративы: `(narratives, [], status)`.
+- Stage 5 (rank) падает для одного нарратива → логируется, остальные продолжают.
+
+**Postconditions:** Delivery получает `IrritatorStatus.level="error"`; counter-signals не отправляются.
+
+---
+
+### UC-4: Blocklist filtering
+
+**Actor:** Digest pipeline (автоматически в validator)
+**Preconditions:** `config.filters.blocklist_keywords` содержит ключевые слова.
+**Main scenario:**
+1. После `search_all_sources()` получен `list[Signal]`.
+2. `validate_signals_async()` проверяет каждый сигнал: `title + snippet` содержит blocklist keyword (case-insensitive substring) → `SignalFiltered`.
+3. Дополнительно: dedup по URL (lower-cased, trailing slash stripped); optional HEAD request для liveness check.
+
+**Postconditions:** Оставшиеся сигналы не содержат blocklist keywords и уникальны по URL.
+
+---
+
+### UC-5: dev.to полнотекстовый поиск (post-issue-#53)
+
+**Actor:** Irritator (sources/devto.py)
+**Preconditions:** `devto` в `IrritatorConfig.sources`.
+**Main scenario:**
+1. `SearchQuery.query` передаётся как полный текст в `?q=<query>` (не первое слово как тег).
+2. dev.to возвращает статьи по полнотекстовому совпадению.
+
+> **Контекст:** до issue-#53 адаптер использовал `params={"tag": query.split()[0].lower()}` — tag-listing call, возвращавший хайп-контент, противоположный counter-signal.
+
+**Postconditions:** Сигналы из dev.to релевантны полному запросу, а не первому слову.
+
+---
+
+## Ubiquitous Language
+
+| Term | Business definition | Aliases to avoid |
+|------|---------------------|------------------|
+| **Narrative** | Доминирующее утверждение, которое сегодняшнее информационное пространство подаёт как само собой разумеющееся — извлечённое из группы `CategorySummary` одного pipeline-запуска. Не персистируется. | Topic, Theme, Consensus |
+| **Signal** | Внешний контент (статья, обсуждение, препринт) из одной из поисковых платформ (HN, Reddit, arXiv, dev.to, Lobsters), полученный по adversarial-запросу. На этом этапе — кандидат, не доказательство. `Signal.score` = **popularity** (upvotes, points) — мера консенсуса платформы, НЕ contradiction score. | Hit, Result, Item |
+| **RankedSignal** | Signal, прошедший LLM-ранжирование. `RankedSignal.score` [1–10] = **contradiction score** — насколько сильно этот контент противоречит или осложняет конкретный Narrative. Семантика противоположна `Signal.score`. | Verified signal |
+| **CounterSignal** | Продуктовый концепт: то, что BC обещает оператору — контент, который разрушает пузырь. В коде не существует отдельного типа `CounterSignal`; им является `RankedSignal` с `score ≥ min_signal_score`. Термин используется в промптах и логах, но не в типах данных. | Counter-narrative, Alternative |
+| **SearchQuery** | Adversarial поисковый запрос для конкретного Narrative с явными negation/failure keywords. Отличается от обычного поиска намеренным противоречием. `intent` — свободная строка, таксономия contradiction-видов не определена (red hotspot). | Query, Search |
+| **IrritatorStatus** | Операторский трейс одного запуска: funnel counters + level (ok/empty/error). `level="empty"` = pipeline отработал корректно, но ничего не выжило. Не различает причины пустоты (red hotspot). | Status, Report |
+
+---
+
+## Domain Data Model
+
+### Narrative
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `claim` | str | непустой; формулировка консенсусного утверждения |
+| `category` | str | соответствует категории из `CategorySummary` |
+| `implicit_assumptions` | `list[str]` | ≥ 1 |
+| `why_worth_challenging` | str | непустой |
+
+Не персистируется. Transient: существует только в памяти одного запуска.
+
+**Известные ограничения модели:** не несёт `dominance` (кол-во источников, повторивших claim) и `confidence` (уверенность LLM, что это консенсус, а не парафраз одного абзаца). Один абзац и 12 статей типизируются одинаково.
+
+### SearchQuery
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `query` | str | adversarial phrasing (failure/criticism/limitations keywords) |
+| `intent` | str | freeform description (нет taxonomy — red hotspot) |
+
+### Signal
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `url` | str | identity для dedup |
+| `title` | str | |
+| `snippet` | str | |
+| `source_name` | str | имя платформы |
+| `published` | `str \| None` | |
+| `score` | float | **popularity** (HN points, Reddit upvotes, etc.) — НЕ contradiction score; семантически противоположен `RankedSignal.score` |
+
+**Lifecycle states:** `raw` (из source adapter) → `validated` (dedup + blocklist + liveness) → implicit `ranked` (участвует в `rank_signals()`). Нет типов для разных состояний — один dataclass проходит все стадии.
+
+### RankedSignal
+
+| Attribute | Type | Invariants |
+|-----------|------|------------|
+| `signal` | `Signal` | |
+| `score` | int | [1..10]; **contradiction score** (НЕ popularity); `score ≥ min_signal_score` для сохранения |
+| `reasoning` | str | объяснение от LLM |
+| `narrative_claim` | str | денормализованная копия `Narrative.claim` |
+
+**Примечание:** `narrative_claim` — строковая копия, не ссылка на агрегат. Провенанс к SearchQuery и исходному Narrative не сохраняется.
+
+### IrritatorStatus
+
+| Attribute | Type | Values |
+|-----------|------|--------|
+| `text` | str | funnel counters: `"N narratives, M signals, K valid, J passed ranking"` |
+| `level` | `"ok" \| "empty" \| "error"` | `ok` = ranked signals существуют; `empty` = pipeline отработал, ничего не выжило; `error` = stage raised |
+
+**Ограничение:** `level="empty"` не различает: (a) сигналы off-topic, (b) on-topic но ниже порога, (c) сигналов вообще не найдено. Оператор не может диагностировать причину по одному level.
+
+---
+
+## Interface Contracts
+
+| Interface | Direction | Protocol | Operations | Handled failures | Unhandled failures |
+|-----------|-----------|----------|-----------|------------------|--------------------|
+| Radar BC (CategorySummary input) | inbound | in-process call | `run_irritator(summaries, config, client)` | пустой список summaries → early return empty | изменение схемы CategorySummary — нет ACL |
+| LLM Providers (narrative extraction) | outbound | HTTPS REST | chat completion, role=EXTRACT_NARRATIVES, temp=0.5 | exception → IrritatorStatus level=error | плохой JSON в ответе LLM — парсер падает |
+| LLM Providers (query generation) | outbound | HTTPS REST | chat completion per narrative, параллельно | exception → IrritatorStatus level=error | |
+| LLM Providers (ranking) | outbound | HTTPS REST | chat completion per narrative | exception per narrative → logged, narrative skipped | |
+| HN Algolia API | outbound | HTTPS REST | `search?query=...&tags=story` | exception caught per-source | API schema change |
+| Reddit JSON API | outbound | HTTPS REST | `r/{sub}/search.json?q=...` | exception caught per-source | API auth change, subreddit ban |
+| arXiv API | outbound | HTTPS REST + XML | `search_query=...` | exception caught per-source | XML schema change |
+| dev.to API | outbound | HTTPS REST | `?q=<full_query>` | exception caught per-source | |
+| Lobsters API | outbound | HTTPS REST | `search?q=...` | exception caught per-source | |
+| Delivery BC (output) | outbound | in-process return | `(list[Narrative], list[RankedSignal], IrritatorStatus)` | — | Delivery форматирует по своим правилам |
+
+---
+
+## NFR
+
+Только механически-проверяемые ограничения:
+
+| Constraint | Enforcement | Artifact |
+|------------|-------------|----------|
+| HTTP-запросы к sources идут через `httpx.AsyncClient` с semaphore=10 | `asyncio.Semaphore(10)` в `sources/__init__.py` | `digest/irritator/sources/__init__.py` |
+| Signal dedup по URL выполняется до ranking | `validate_signals_async()` вызывается перед `rank_signals()` | `digest/irritator/__init__.py` |
+| Blocklist применяется до ranking | тот же порядок в orchestrator | `digest/irritator/__init__.py` |
+| Calibration anchors в ranker prompt зафиксированы | текст промпта в `ranker.py` | `digest/irritator/ranker.py` |
+
+---
+
+## Internal Compliance
+
+| Norm | Enforcement type | Artifact | Honor-system gap? |
+|------|-----------------|----------|-------------------|
+| Type hints на всех функциях | mypy strict | CI | No |
+| Нет неиспользуемых импортов | ruff F401 | pre-commit + CI | No |
+| async/await для всех I/O | mypy + review | — | Yes |
+| Нет реального HTTP в тестах | pytest convention | `tests/test_sources_*.py` | Yes — нет network isolation в CI |
+| Per-stage exception isolation | code review | orchestrator паттерн | Yes |
+
+---
+
+## Red Hotspots
+
+1. **Provenance edge отсутствует**: Signal не помнит, каким SearchQuery и Narrative он был порождён. All-pairs ranking не может ответить: "для нарратива N мы вообще нашли что-нибудь?"
+2. **Narrative dominance/confidence не моделируются**: один абзац и 12 источников — один тип.
+3. **Нет bubble fingerprint как explicit BC input**: Irritator не знает об информационной диете оператора вне одного запуска.
+4. **Source-narrative fit unmodelled**: нет SourceProfile; arXiv и HN получают одинаковые запросы.
+5. **`IrritatorStatus.level="empty"` без reason code**: оператор не может диагностировать причину.
+6. **Нет feedback loop**: operator votes не доходят до Irritator; система не обучается на том, кликали ли на counter-signals.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,12 @@
-# Plan — Issue #55: Verbose and repetitive article summaries
+# Plan — Issues #55, #71, #72 (bundled PR)
+
+> **Scope note (2026-04-28):** This branch bundles three issues:
+> - **#55** — terse article summaries (Radar BC, `summarizer.py`)
+> - **#71** — `/bubble` filter bubble analytics command (Delivery BC, `feedback.py`, `source_scorer.py`)
+> - **#72** — fix `/bubble` to show topic categories instead of source names (same files)
+>
+> Issues #71 and #72 are fully implemented and tested on this branch. The original plan below
+> covers #55 only; #71/#72 have no separate plan artifact (they were smaller stories).
 
 ## 1. Problem restatement
 

--- a/tests/test_bubble_analytics.py
+++ b/tests/test_bubble_analytics.py
@@ -280,8 +280,11 @@ def _bubble_update(chat_id: int = 999) -> dict[str, object]:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_collect_feedback_bubble_command_sends_report(tmp_path: Path) -> None:
-    """Receiving /bubble should trigger a sendMessage with a non-empty report."""
+async def test_collect_feedback_bubble_command_sends_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receiving /bubble from the owner should trigger a sendMessage with a non-empty report."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "999")
     token = "tok"
     store = FeedbackStore()
 
@@ -311,8 +314,40 @@ async def test_collect_feedback_bubble_command_sends_report(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_collect_feedback_bubble_empty_cache_no_crash(tmp_path: Path) -> None:
+async def test_collect_feedback_bubble_unknown_chat_id_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A /bubble from an unknown chat_id must be silently dropped — no sendMessage."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "1111")  # owner is 1111
+    token = "tok_auth"
+    store = FeedbackStore()
+
+    respx.get(f"https://api.telegram.org/bot{token}/getWebhookInfo").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": {"url": "", "pending_update_count": 0}})
+    )
+    respx.post(f"https://api.telegram.org/bot{token}/deleteWebhook").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    respx.post(f"https://api.telegram.org/bot{token}/getUpdates").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": [_bubble_update(chat_id=999)]})
+    )
+    send_mock = respx.post(f"https://api.telegram.org/bot{token}/sendMessage").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+    )
+
+    result = await collect_feedback(token, store, cache_dir=str(tmp_path))
+
+    assert not send_mock.called
+    assert result.last_update_id == 5001  # update still acked
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_collect_feedback_bubble_empty_cache_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Empty cache_dir must not crash — sends a report with 'No data'."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "42")
     token = "tok2"
     store = FeedbackStore()
 
@@ -340,9 +375,10 @@ async def test_collect_feedback_bubble_empty_cache_no_crash(tmp_path: Path) -> N
 @pytest.mark.asyncio
 @respx.mock
 async def test_collect_feedback_bubble_send_failure_does_not_propagate(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """If sendMessage fails for /bubble, the exception must be swallowed (logged only)."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "7")
     token = "tok3"
     store = FeedbackStore()
 

--- a/tests/test_bubble_analytics.py
+++ b/tests/test_bubble_analytics.py
@@ -397,3 +397,44 @@ async def test_collect_feedback_bubble_send_failure_does_not_propagate(
 
     result = await collect_feedback(token, store, cache_dir=str(tmp_path))
     assert result.last_update_id == 5001  # update was still processed
+
+
+def _status_update(chat_id: int = 999) -> dict[str, object]:
+    return {
+        "update_id": 6001,
+        "message": {
+            "message_id": 2,
+            "from": {"id": chat_id},
+            "chat": {"id": chat_id, "type": "private"},
+            "text": "/status",
+        },
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_collect_feedback_status_unknown_chat_id_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A /status from an unknown chat_id must be silently dropped — no sendMessage."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "1111")
+    token = "tok_status_auth"
+    store = FeedbackStore()
+
+    respx.get(f"https://api.telegram.org/bot{token}/getWebhookInfo").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": {"url": "", "pending_update_count": 0}})
+    )
+    respx.post(f"https://api.telegram.org/bot{token}/deleteWebhook").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    respx.post(f"https://api.telegram.org/bot{token}/getUpdates").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": [_status_update(chat_id=999)]})
+    )
+    send_mock = respx.post(f"https://api.telegram.org/bot{token}/sendMessage").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+    )
+
+    result = await collect_feedback(token, store, cache_dir=str(tmp_path))
+
+    assert not send_mock.called
+    assert result.last_update_id == 6001

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -746,8 +746,9 @@ async def test_collect_feedback_src_no_callback() -> None:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_collect_feedback_status_command() -> None:
+async def test_collect_feedback_status_command(monkeypatch: pytest.MonkeyPatch) -> None:
     """/status message triggers a sendMessage reply with digest info."""
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "99999")
     token = "testtoken"
     chat_id = "99999"
     store = FeedbackStore(


### PR DESCRIPTION
## Summary

- **#55 — Terse article summaries (Radar BC):** Tighten all 14 prompt strings to require non-obvious focus; reduce per-article target from 2-3 to 1-2 sentences; add `_cap_sentences()` mechanical cap enforced on `ArticleSummary.summary`
- **#71 — /bubble filter bubble analytics:** New Telegram command reporting diversity score (Shannon entropy), 7-day category breakdown, 14-day feedback summary, source lifecycle counters
- **#72 — Fix /bubble to show topic categories:** Primary view shows categories (via `source_category_map`), falling back to top-5 sources when map is absent

## Security fixes (from /review + codex-review)

- **Auth gate on `/status` and `/bubble`:** Both commands now require `chat_id == TELEGRAM_CHAT_ID`; unknown senders silently dropped. Startup warning logged when `TELEGRAM_CHAT_ID` is unset.
- **Token-safe logging:** Exception handlers log `exc.__class__.__name__` instead of full `exc` repr, preventing httpx URL (with embedded bot token) from reaching logs.
- **Telegram text limit:** `report[:TELEGRAM_TEXT_LIMIT]` (4096) prevents silent 400 on long reports.

## Reliability fixes (from reliability-reviewer)

- `article_source_map` now included in delivery-failure rollback (prevented FIFO eviction of undelivered card mappings)
- Rollback path logs `info` with before/after counters for observability

## Docs

- `docs/domain/digest/overview.md` — complete post-interview sections (5 Use Cases, Domain Data Model, Interface Contracts, NFR, Internal Compliance); BubbleReport read model; new events
- `docs/domain/irritator/overview.md` — new canonical BC overview (migrated from research-format `irritator-bc.md`); full UL including CounterSignal; Context Map Conformist fix
- `docs/ARCHITECTURE.md` — fix `python -m src` → `python -m digest`; fix `markdown_writer.py` → `delivery/markdown.py`; add missing cache files; fix `/bubble` description; link to BC docs
- `docs/domain/irritator-bc.md` — ARCHIVED DIAGNOSTIC banner pointing to canonical file

## Test plan

- [x] `tests/test_radar_summarizer.py` — prompt-content assertions (all 10 lang×style), `_cap_sentences` unit, `pick_top_articles` cap via mock
- [x] `tests/test_bubble_analytics.py` — `compute_bubble_report`, `_diversity_score`, handler integration; unknown chat_id silently dropped (bubble + status)
- [x] `tests/test_feedback.py` — existing /status test updated with `monkeypatch(TELEGRAM_CHAT_ID)`
- [x] 481 tests pass, 0 failures
- [x] `ruff check` clean
- [x] `/review` (Claude) — all BLOCKs resolved
- [x] `/codex-review` (Codex, gpt-5.2) — all BLOCKs resolved

Closes #55
Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)